### PR TITLE
Serial Frame Capture

### DIFF
--- a/picamera2/frame.py
+++ b/picamera2/frame.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
-import numpy as np
+
 from dataclasses import dataclass
+
+import numpy as np
+
 from picamera2.request import CompletedRequest
+
 
 @dataclass
 class CameraFrame:
@@ -16,5 +20,5 @@ class CameraFrame:
         return cls(
             array=request.make_array(name),
             metadata=request.get_metadata(),
-            config=request.config
+            config=request.config,
         )

--- a/picamera2/frame.py
+++ b/picamera2/frame.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import numpy as np
+from dataclasses import dataclass
+from picamera2.request import CompletedRequest
+
+@dataclass
+class CameraFrame:
+    array: np.ndarray
+
+    config: dict
+
+    metadata: dict
+
+    @classmethod
+    def from_request(cls, name: str, request: CompletedRequest) -> CameraFrame:
+        return cls(
+            array=request.make_array(name),
+            metadata=request.get_metadata(),
+            config=request.config
+        )

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -21,11 +21,11 @@ from PIL import Image
 import picamera2.formats as formats
 from picamera2.configuration import CameraConfiguration
 from picamera2.controls import Controls
+from picamera2.frame import CameraFrame
 from picamera2.lc_helpers import lc_unpack, lc_unpack_controls
 from picamera2.previews import NullPreview
 from picamera2.request import CompletedRequest, LoopTask
 from picamera2.sensor_format import SensorFormat
-from picamera2.frame import CameraFrame
 from picamera2.stream_config import (
     align_stream,
     check_stream_config,
@@ -1274,7 +1274,7 @@ class Picamera2:
 
     def _capture_frame(self, name: str, request: CompletedRequest) -> CameraFrame:
         return CameraFrame.from_request(name, request)
-    
+
     def capture_frame(self, name: str = "main") -> CameraFrame:
         """Make a CameraFrame from the next frame in the named stream.
 
@@ -1288,5 +1288,9 @@ class Picamera2:
     def capture_serial_frames_async(self, n_frames: int, name="main") -> List[Future]:
         """Capture a number of frames from the named stream, returning a list of CameraFrames."""
         return self._dispatch_loop_tasks(
-            LoopTask.with_request(self._capture_frame, name) for _ in range(n_frames)
+            *(LoopTask.with_request(self._capture_frame, name) for _ in range(n_frames))
         )
+
+    def capture_serial_frames(self, n_frames: int, name="main") -> List[CameraFrame]:
+        """Capture a number of frames from the named stream, returning a list of CameraFrames."""
+        return [f.result() for f in self.capture_serial_frames_async(n_frames, name)]

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -25,6 +25,7 @@ from picamera2.lc_helpers import lc_unpack, lc_unpack_controls
 from picamera2.previews import NullPreview
 from picamera2.request import CompletedRequest, LoopTask
 from picamera2.sensor_format import SensorFormat
+from picamera2.frame import CameraFrame
 from picamera2.stream_config import (
     align_stream,
     check_stream_config,
@@ -1270,3 +1271,22 @@ class Picamera2:
         return self._dispatch_with_temporary_mode(
             LoopTask.with_request(self._capture_image, name), camera_config
         ).result()
+
+    def _capture_frame(self, name: str, request: CompletedRequest) -> CameraFrame:
+        return CameraFrame.from_request(name, request)
+    
+    def capture_frame(self, name: str = "main") -> CameraFrame:
+        """Make a CameraFrame from the next frame in the named stream.
+
+        :param name: Stream name, defaults to "main"
+        :type name: str, optional
+        """
+        return self._dispatch_loop_tasks(
+            LoopTask.with_request(self._capture_frame, name)
+        )[0].result()
+
+    def capture_serial_frames_async(self, n_frames: int, name="main") -> List[Future]:
+        """Capture a number of frames from the named stream, returning a list of CameraFrames."""
+        return self._dispatch_loop_tasks(
+            LoopTask.with_request(self._capture_frame, name) for _ in range(n_frames)
+        )

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -1,0 +1,18 @@
+from concurrent.futures import Future
+from picamera2 import Picamera2
+from picamera2.frame import CameraFrame
+
+
+camera = Picamera2()
+
+camera.start()
+
+futures = camera.capture_serial_frames_async(5)
+
+camera.stop()
+camera.close()
+
+
+for f in futures:
+    assert isinstance(f, Future)
+    assert isinstance(f.result(), CameraFrame)

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -1,7 +1,7 @@
 from concurrent.futures import Future
+
 from picamera2 import Picamera2
 from picamera2.frame import CameraFrame
-
 
 camera = Picamera2()
 


### PR DESCRIPTION
This PR allows the caller to collect a series of sequential requests. These are entered as a block and can not be preempted/cached as previously.