### PR TITLE
Move Config Builders and Rename Config Classes

### DIFF
--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -3,7 +3,7 @@ import sys
 sys.path.append("/usr/lib/python3/dist-packages")
 import libcamera
 
-from picamera2.configuration import CameraConfiguration, StreamConfiguration
+from picamera2.configuration import CameraConfig, StreamConfig
 from picamera2.controls import Controls
 from picamera2.converters import YUV420_to_RGB
 from picamera2.lc_helpers import libcamera_color_spaces_eq, libcamera_transforms_eq
@@ -19,8 +19,8 @@ libcamera.ColorSpace.__eq__ = libcamera_color_spaces_eq
 
 
 __all__ = [
-    "CameraConfiguration",
-    "StreamConfiguration",
+    "CameraConfig",
+    "StreamConfig",
     "Controls",
     "YUV420_to_RGB",
     "Picamera2",

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -196,7 +196,7 @@ class CameraConfig:
 
     # TODO(meawoppl) - These can likely be made static/hoisted
     @classmethod
-    def create_preview_configuration(
+    def for_preview(
         cls,
         camera: Picamera2,
         main: dict = {},
@@ -208,8 +208,6 @@ class CameraConfig:
         controls={},
     ) -> CameraConfig:
         """Make a configuration suitable for camera preview."""
-        camera.requires_camera()
-
         main_stream = StreamConfig(format="XBGR8888", size=(640, 480))
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)
@@ -253,7 +251,7 @@ class CameraConfig:
         )
 
     @classmethod
-    def create_still_configuration(
+    def for_still(
         cls,
         camera,
         main={},
@@ -265,8 +263,6 @@ class CameraConfig:
         controls={},
     ) -> CameraConfig:
         """Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."""
-        camera.requires_camera()
-
         main_stream = StreamConfig(format="BGR888", size=camera.sensor_resolution)
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)
@@ -307,7 +303,7 @@ class CameraConfig:
         )
 
     @classmethod
-    def create_video_configuration(
+    def for_video(
         cls,
         camera: Picamera2,
         main={},
@@ -319,7 +315,6 @@ class CameraConfig:
         controls={},
     ) -> CameraConfig:
         """Make a configuration suitable for video recording."""
-        camera.requires_camera()
         main_stream = StreamConfig(format="XBGR8888", size=(1280, 720))
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -19,6 +19,7 @@ def _assert_type(thing: Any, type_) -> None:
     if not isinstance(thing, type_):
         raise TypeError(f"{thing} should be a {type_} not {type(thing)}")
 
+
 _raw_stream_ignore_list = [
     "bit_depth",
     "crop_limits",
@@ -26,6 +27,7 @@ _raw_stream_ignore_list = [
     "fps",
     "unpacked",
 ]
+
 
 @dataclass
 class StreamConfiguration:
@@ -267,7 +269,9 @@ class CameraConfiguration:
         """Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."""
         camera.requires_camera()
 
-        main_stream = StreamConfiguration(format="BGR888", size=camera.sensor_resolution)
+        main_stream = StreamConfiguration(
+            format="BGR888", size=camera.sensor_resolution
+        )
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)
 

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -30,7 +30,7 @@ _raw_stream_ignore_list = [
 
 
 @dataclass
-class StreamConfiguration:
+class StreamConfig:
     size: tuple[int, int]
     format: Optional[str] = None
     stride: Optional[int] = None
@@ -104,7 +104,7 @@ class StreamConfiguration:
 
 
 @dataclass
-class CameraConfiguration:
+class CameraConfig:
     camera: Picamera2
     use_case: str
     buffer_count: int
@@ -114,9 +114,9 @@ class CameraConfiguration:
     # The are allowed to be a dict when user input, but will
     # be transformed to the proper class by the __post_init__ method.
     controls: Controls | dict
-    main: StreamConfiguration | dict
-    lores: Optional[StreamConfiguration | dict] = None
-    raw: Optional[StreamConfiguration | dict] = None
+    main: StreamConfig | dict
+    lores: Optional[StreamConfig | dict] = None
+    raw: Optional[StreamConfig | dict] = None
 
     # TODO: Remove forward references.
     @property
@@ -137,14 +137,12 @@ class CameraConfiguration:
 
     def enable_lores(self, enable: bool = True) -> None:
         self.lores = (
-            StreamConfiguration(size=self.main.size, format="YUV420")
-            if enable
-            else None
+            StreamConfig(size=self.main.size, format="YUV420") if enable else None
         )
 
     def enable_raw(self, enable: bool = True) -> None:
         self.raw = (
-            StreamConfiguration(size=self.main.size, format=self.camera.sensor_format)
+            StreamConfig(size=self.main.size, format=self.camera.sensor_format)
             if enable
             else None
         )
@@ -155,7 +153,7 @@ class CameraConfiguration:
             self.lores.align(optimal)
         # No sense trying to align the raw stream.
 
-    def get_config(self, config_name: str) -> StreamConfiguration:
+    def get_config(self, config_name: str) -> StreamConfig:
         # TODO(meawoppl) - backcompat shim. remove me.
         if config_name == "main":
             return self.main
@@ -171,13 +169,13 @@ class CameraConfiguration:
             self.controls = Controls(self.camera, self.controls)
         if isinstance(self.main, dict):
             _log.warning("CameraConfiguration 'main' should be a StreamConfiguration")
-            self.main = StreamConfiguration(**self.main)
+            self.main = StreamConfig(**self.main)
         if isinstance(self.lores, dict):
             _log.warning("CameraConfiguration 'lores' should be a StreamConfiguration")
-            self.lores = StreamConfiguration(**self.lores)
+            self.lores = StreamConfig(**self.lores)
         if isinstance(self.raw, dict):
             _log.warning("CameraConfiguration 'raw' should be a StreamConfiguration")
-            self.raw = StreamConfiguration(**self.raw)
+            self.raw = StreamConfig(**self.raw)
 
         # Check the entire camera configuration for errors.
         _assert_type(self.colour_space, libcamera._libcamera.ColorSpace)
@@ -208,23 +206,23 @@ class CameraConfiguration:
         colour_space=libcamera.ColorSpace.Sycc(),
         buffer_count=4,
         controls={},
-    ) -> CameraConfiguration:
+    ) -> CameraConfig:
         """Make a configuration suitable for camera preview."""
         camera.requires_camera()
 
-        main_stream = StreamConfiguration(format="XBGR8888", size=(640, 480))
+        main_stream = StreamConfig(format="XBGR8888", size=(640, 480))
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)
 
         if lores is not None:
-            lores_stream = StreamConfiguration(format="YUV420", size=main_stream.size)
+            lores_stream = StreamConfig(format="YUV420", size=main_stream.size)
             lores_stream = replace(lores_stream, **lores)
             lores_stream.align(optimal=False)
         else:
             lores_stream = None
 
         if raw is not None:
-            raw_stream = StreamConfiguration(
+            raw_stream = StreamConfig(
                 format=camera.sensor_format, size=camera.sensor_resolution
             )
             updates: dict = raw.copy()
@@ -265,25 +263,23 @@ class CameraConfiguration:
         colour_space=libcamera.ColorSpace.Sycc(),
         buffer_count=1,
         controls={},
-    ) -> CameraConfiguration:
+    ) -> CameraConfig:
         """Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."""
         camera.requires_camera()
 
-        main_stream = StreamConfiguration(
-            format="BGR888", size=camera.sensor_resolution
-        )
+        main_stream = StreamConfig(format="BGR888", size=camera.sensor_resolution)
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)
 
         if lores is not None:
-            lores_stream = StreamConfiguration(format="YUV420", size=main_stream.size)
+            lores_stream = StreamConfig(format="YUV420", size=main_stream.size)
             lores_stream = replace(lores_stream, **lores)
             lores_stream.align(optimal=False)
         else:
             lores_stream = None
 
         if raw is not None:
-            raw_stream = StreamConfiguration(
+            raw_stream = StreamConfig(
                 format=camera.sensor_format, size=main_stream.size
             )
             raw_stream = replace(raw_stream, **raw)
@@ -321,22 +317,22 @@ class CameraConfiguration:
         colour_space=None,
         buffer_count=6,
         controls={},
-    ) -> CameraConfiguration:
+    ) -> CameraConfig:
         """Make a configuration suitable for video recording."""
         camera.requires_camera()
-        main_stream = StreamConfiguration(format="XBGR8888", size=(1280, 720))
+        main_stream = StreamConfig(format="XBGR8888", size=(1280, 720))
         main_stream = replace(main_stream, **main)
         main_stream.align(optimal=False)
 
         if lores is not None:
-            lores_stream = StreamConfiguration(format="YUV420", size=main_stream.size)
+            lores_stream = StreamConfig(format="YUV420", size=main_stream.size)
             lores_stream = replace(lores_stream, **lores)
             lores_stream.align(optimal=False)
         else:
             lores_stream = None
 
         if raw is not None:
-            raw_stream = StreamConfiguration(
+            raw_stream = StreamConfig(
                 format=camera.sensor_format, size=main_stream.size
             )
             raw_stream = replace(raw_stream, **raw)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -236,9 +236,9 @@ class Picamera2:
 
             # Configuration requires various bits of information from the camera
             # so we build the default configurations here
-            self.preview_configuration = CameraConfig.create_preview_configuration(self)
-            self.still_configuration = CameraConfig.create_still_configuration(self)
-            self.video_configuration = CameraConfig.create_video_configuration(self)
+            self.preview_configuration = CameraConfig.for_preview(self)
+            self.still_configuration = CameraConfig.for_still(self)
+            self.video_configuration = CameraConfig.for_video(self)
         except Exception as e:
             _log.error("Camera __init__ sequence did not complete.", exc_info=e)
             raise RuntimeError("Camera __init__ sequence did not complete.") from e
@@ -454,7 +454,7 @@ class Picamera2:
             for size in raw_formats.sizes(pix):
                 cam_mode = all_format.copy()
                 cam_mode["size"] = (size.width, size.height)
-                temp_config = CameraConfig.create_preview_configuration(
+                temp_config = CameraConfig.for_preview(
                     camera=self, raw={"format": str(pix), "size": cam_mode["size"]}
                 )
                 self.configure(temp_config)
@@ -686,7 +686,7 @@ class Picamera2:
         camera_config = self._config_opts(config)
 
         if camera_config is None:
-            camera_config = CameraConfig.create_preview_configuration(camera=self)
+            camera_config = CameraConfig.for_preview(camera=self)
 
         # Mark ourselves as unconfigured.
         self.libcamera_config = None

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -236,9 +236,15 @@ class Picamera2:
 
             # Configuration requires various bits of information from the camera
             # so we build the default configurations here
-            self.preview_configuration = CameraConfiguration.create_preview_configuration(self)
-            self.still_configuration = CameraConfiguration.create_still_configuration(self)
-            self.video_configuration = CameraConfiguration.create_video_configuration(self)
+            self.preview_configuration = (
+                CameraConfiguration.create_preview_configuration(self)
+            )
+            self.still_configuration = CameraConfiguration.create_still_configuration(
+                self
+            )
+            self.video_configuration = CameraConfiguration.create_video_configuration(
+                self
+            )
         except Exception as e:
             _log.error("Camera __init__ sequence did not complete.", exc_info=e)
             raise RuntimeError("Camera __init__ sequence did not complete.") from e
@@ -692,7 +698,9 @@ class Picamera2:
         camera_config = self._config_opts(config)
 
         if camera_config is None:
-            camera_config = CameraConfiguration.create_preview_configuration()
+            camera_config = CameraConfiguration.create_preview_configuration(
+                camera=self
+            )
 
         # Mark ourselves as unconfigured.
         self.libcamera_config = None

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -15,7 +15,7 @@ from PIL import Image
 
 import picamera2.formats as formats
 from picamera2 import formats
-from picamera2.configuration import CameraConfiguration
+from picamera2.configuration import CameraConfig
 from picamera2.lc_helpers import lc_unpack
 
 _log = getLogger(__name__)
@@ -49,7 +49,7 @@ class MappedBuffer:
 
 class AbstractCompletedRequest(ABC):
     @abstractmethod
-    def get_config(self, name: str) -> CameraConfiguration:
+    def get_config(self, name: str) -> CameraConfig:
         raise NotImplementedError()
 
     @abstractmethod
@@ -129,7 +129,7 @@ class CompletedRequest(AbstractCompletedRequest):
     def __init__(
         self,
         lc_request,
-        config: CameraConfiguration,
+        config: CameraConfig,
         stream_map: Dict[str, Any],
         cleanup: Callable[[], None],
     ):

--- a/tests/async_test.py
+++ b/tests/async_test.py
@@ -6,9 +6,10 @@ from threading import Thread
 from typing import List
 
 from picamera2 import Picamera2
+from picamera2.configuration import CameraConfiguration
 
 camera = Picamera2()
-config = camera.create_preview_configuration()
+config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(config)
 camera.start()
 abort = False

--- a/tests/async_test.py
+++ b/tests/async_test.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2
 from picamera2.configuration import CameraConfig
 
 camera = Picamera2()
-config = CameraConfig.create_preview_configuration(camera)
+config = CameraConfig.for_preview(camera)
 camera.configure(config)
 camera.start()
 abort = False

--- a/tests/async_test.py
+++ b/tests/async_test.py
@@ -6,10 +6,10 @@ from threading import Thread
 from typing import List
 
 from picamera2 import Picamera2
-from picamera2.configuration import CameraConfiguration
+from picamera2.configuration import CameraConfig
 
 camera = Picamera2()
-config = CameraConfiguration.create_preview_configuration(camera)
+config = CameraConfig.create_preview_configuration(camera)
 camera.configure(config)
 camera.start()
 abort = False

--- a/tests/capture_circular.py
+++ b/tests/capture_circular.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python3
 import numpy as np
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 lsize = (320, 240)
 camera = Picamera2()
-video_config = camera.create_video_configuration(
+video_config = CameraConfiguration.create_video_configuration(
+    camera,
     main={"size": (1280, 720), "format": "RGB888"},
     lores={"size": lsize, "format": "YUV420"},
 )

--- a/tests/capture_circular.py
+++ b/tests/capture_circular.py
@@ -5,7 +5,7 @@ from picamera2 import CameraConfig, Picamera2
 
 lsize = (320, 240)
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(
+video_config = CameraConfig.for_video(
     camera,
     main={"size": (1280, 720), "format": "RGB888"},
     lores={"size": lsize, "format": "YUV420"},

--- a/tests/capture_circular.py
+++ b/tests/capture_circular.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import numpy as np
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 lsize = (320, 240)
 camera = Picamera2()

--- a/tests/capture_circular.py
+++ b/tests/capture_circular.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 import numpy as np
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 lsize = (320, 240)
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(
+video_config = CameraConfig.create_video_configuration(
     camera,
     main={"size": (1280, 720), "format": "RGB888"},
     lores={"size": lsize, "format": "YUV420"},

--- a/tests/capture_circular_nooutput.py
+++ b/tests/capture_circular_nooutput.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
@@ -7,7 +7,7 @@ fps = 30
 dur = 5
 
 micro = int((1 / fps) * 1000000)
-video_cfg = camera.create_video_configuration()
+video_cfg = CameraConfiguration.create_video_configuration(camera)
 video_cfg.controls.FrameDurationLimits = (micro, micro)
 camera.configure(video_cfg)
 

--- a/tests/capture_circular_nooutput.py
+++ b/tests/capture_circular_nooutput.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
@@ -7,7 +7,7 @@ fps = 30
 dur = 5
 
 micro = int((1 / fps) * 1000000)
-video_cfg = CameraConfiguration.create_video_configuration(camera)
+video_cfg = CameraConfig.create_video_configuration(camera)
 video_cfg.controls.FrameDurationLimits = (micro, micro)
 camera.configure(video_cfg)
 

--- a/tests/capture_circular_nooutput.py
+++ b/tests/capture_circular_nooutput.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()

--- a/tests/capture_circular_nooutput.py
+++ b/tests/capture_circular_nooutput.py
@@ -7,7 +7,7 @@ fps = 30
 dur = 5
 
 micro = int((1 / fps) * 1000000)
-video_cfg = CameraConfig.create_video_configuration(camera)
+video_cfg = CameraConfig.for_video(camera)
 video_cfg.controls.FrameDurationLimits = (micro, micro)
 camera.configure(video_cfg)
 

--- a/tests/capture_dng_and_jpeg.py
+++ b/tests/capture_dng_and_jpeg.py
@@ -1,18 +1,18 @@
 #!/usr/bin/python3
 # Capture a DNG and a JPEG made from the same raw data.
 from picamera2 import Picamera2
-from picamera2.configuration import CameraConfiguration
+from picamera2.configuration import CameraConfig
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure("preview")
 
 camera.start()
 camera.discard_frames(2)
 
-capture_config = CameraConfiguration.create_still_configuration(camera, raw={})
+capture_config = CameraConfig.create_still_configuration(camera, raw={})
 camera.switch_mode(capture_config).result()
 request = camera.capture_request(capture_config).result()
 request.make_image("main").convert("RGB").save("full.jpg")

--- a/tests/capture_dng_and_jpeg.py
+++ b/tests/capture_dng_and_jpeg.py
@@ -6,13 +6,13 @@ from picamera2.configuration import CameraConfig
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure("preview")
 
 camera.start()
 camera.discard_frames(2)
 
-capture_config = CameraConfig.create_still_configuration(camera, raw={})
+capture_config = CameraConfig.for_still(camera, raw={})
 camera.switch_mode(capture_config).result()
 request = camera.capture_request(capture_config).result()
 request.make_image("main").convert("RGB").save("full.jpg")

--- a/tests/capture_dng_and_jpeg.py
+++ b/tests/capture_dng_and_jpeg.py
@@ -1,18 +1,19 @@
 #!/usr/bin/python3
 # Capture a DNG and a JPEG made from the same raw data.
 from picamera2 import Picamera2
+from picamera2.configuration import CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
-capture_config = camera.create_still_configuration(raw={})
-camera.configure(preview_config)
+preview_config = CameraConfiguration.create_preview_configuration(camera)
+camera.configure("preview")
 
 camera.start()
 camera.discard_frames(2)
-camera.switch_mode(capture_config).result()
 
+capture_config = CameraConfiguration.create_still_configuration(camera, raw={})
+camera.switch_mode(capture_config).result()
 request = camera.capture_request(capture_config).result()
 request.make_image("main").convert("RGB").save("full.jpg")
 request.release()

--- a/tests/capture_dng_and_jpeg_helpers.py
+++ b/tests/capture_dng_and_jpeg_helpers.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python3
 # Capture a DNG and a JPEG made from the same raw data.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
+from picamera2.configuration import CameraConfiguration
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
-capture_config = camera.create_still_configuration(raw={})
+preview_config = CameraConfiguration.create_preview_configuration(camera)
+capture_config = CameraConfiguration.create_still_configuration(camera, raw={})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_dng_and_jpeg_helpers.py
+++ b/tests/capture_dng_and_jpeg_helpers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # Capture a DNG and a JPEG made from the same raw data.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.configuration import CameraConfiguration
 from picamera2.testing import mature_after_frames_or_timeout
 

--- a/tests/capture_dng_and_jpeg_helpers.py
+++ b/tests/capture_dng_and_jpeg_helpers.py
@@ -7,8 +7,8 @@ from picamera2.testing import mature_after_frames_or_timeout
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
-capture_config = CameraConfig.create_still_configuration(camera, raw={})
+preview_config = CameraConfig.for_preview(camera)
+capture_config = CameraConfig.for_still(camera, raw={})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_dng_and_jpeg_helpers.py
+++ b/tests/capture_dng_and_jpeg_helpers.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python3
 # Capture a DNG and a JPEG made from the same raw data.
-from picamera2 import CameraConfiguration, Picamera2
-from picamera2.configuration import CameraConfiguration
+from picamera2 import CameraConfig, Picamera2
+from picamera2.configuration import CameraConfig
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
-capture_config = CameraConfiguration.create_still_configuration(camera, raw={})
+preview_config = CameraConfig.create_preview_configuration(camera)
+capture_config = CameraConfig.create_still_configuration(camera, raw={})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_full_res.py
+++ b/tests/capture_full_res.py
@@ -6,8 +6,8 @@ from picamera2.configuration import CameraConfig
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
-capture_config = CameraConfig.create_still_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
+capture_config = CameraConfig.for_still(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_full_res.py
+++ b/tests/capture_full_res.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python3
 # Capture a JPEG while still running in the preview mode.
-from picamera2 import CameraConfiguration, Picamera2
-from picamera2.configuration import CameraConfiguration
+from picamera2 import CameraConfig, Picamera2
+from picamera2.configuration import CameraConfig
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
-capture_config = CameraConfiguration.create_still_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
+capture_config = CameraConfig.create_still_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_full_res.py
+++ b/tests/capture_full_res.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 # Capture a JPEG while still running in the preview mode.
-from picamera2 import Picamera2, CameraConfiguration
-
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.configuration import CameraConfiguration
 
 camera = Picamera2()

--- a/tests/capture_full_res.py
+++ b/tests/capture_full_res.py
@@ -1,12 +1,14 @@
 #!/usr/bin/python3
 # Capture a JPEG while still running in the preview mode.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
+
+from picamera2.configuration import CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
-capture_config = camera.create_still_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
+capture_config = CameraConfiguration.create_still_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_headless.py
+++ b/tests/capture_headless.py
@@ -2,7 +2,7 @@
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-config = CameraConfig.create_still_configuration(camera)
+config = CameraConfig.for_still(camera)
 camera.configure(config)
 
 camera.start()

--- a/tests/capture_headless.py
+++ b/tests/capture_headless.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-config = camera.create_still_configuration()
+config = CameraConfiguration.create_still_configuration(camera)
 camera.configure(config)
 
 camera.start()

--- a/tests/capture_headless.py
+++ b/tests/capture_headless.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-config = CameraConfiguration.create_still_configuration(camera)
+config = CameraConfig.create_still_configuration(camera)
 camera.configure(config)
 
 camera.start()

--- a/tests/capture_headless.py
+++ b/tests/capture_headless.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 config = CameraConfiguration.create_still_configuration(camera)

--- a/tests/capture_image_full_res.py
+++ b/tests/capture_image_full_res.py
@@ -2,13 +2,13 @@
 # Capture a full resolution image to memory rather than to a file.
 from PIL import Image
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
 camera.start_preview()
-preview_config = camera.create_preview_configuration()
-capture_config = camera.create_still_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
+capture_config = CameraConfiguration.create_still_configuration(camera)
 
 camera.configure(preview_config)
 camera.start()

--- a/tests/capture_image_full_res.py
+++ b/tests/capture_image_full_res.py
@@ -2,7 +2,7 @@
 # Capture a full resolution image to memory rather than to a file.
 from PIL import Image
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()

--- a/tests/capture_image_full_res.py
+++ b/tests/capture_image_full_res.py
@@ -2,13 +2,13 @@
 # Capture a full resolution image to memory rather than to a file.
 from PIL import Image
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
 camera.start_preview()
-preview_config = CameraConfiguration.create_preview_configuration(camera)
-capture_config = CameraConfiguration.create_still_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
+capture_config = CameraConfig.create_still_configuration(camera)
 
 camera.configure(preview_config)
 camera.start()

--- a/tests/capture_image_full_res.py
+++ b/tests/capture_image_full_res.py
@@ -7,8 +7,8 @@ from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
 camera.start_preview()
-preview_config = CameraConfig.create_preview_configuration(camera)
-capture_config = CameraConfig.create_still_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
+capture_config = CameraConfig.for_still(camera)
 
 camera.configure(preview_config)
 camera.start()

--- a/tests/capture_jpeg.py
+++ b/tests/capture_jpeg.py
@@ -2,11 +2,11 @@
 # Capture a JPEG while still running in the preview mode. When you
 # capture to a file, the return value is the metadata for that image.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 
-preview_config = CameraConfiguration.create_preview_configuration(
+preview_config = CameraConfig.create_preview_configuration(
     camera, main={"size": (800, 600)}
 )
 camera.configure(preview_config)

--- a/tests/capture_jpeg.py
+++ b/tests/capture_jpeg.py
@@ -6,9 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 
-preview_config = CameraConfig.create_preview_configuration(
-    camera, main={"size": (800, 600)}
-)
+preview_config = CameraConfig.for_preview(camera, main={"size": (800, 600)})
 camera.configure(preview_config)
 
 camera.start_preview()

--- a/tests/capture_jpeg.py
+++ b/tests/capture_jpeg.py
@@ -2,11 +2,11 @@
 # Capture a JPEG while still running in the preview mode. When you
 # capture to a file, the return value is the metadata for that image.
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 
-preview_config = camera.create_preview_configuration(main={"size": (800, 600)})
+preview_config = CameraConfiguration.create_preview_configuration(camera, main={"size": (800, 600)})
 camera.configure(preview_config)
 
 camera.start_preview()

--- a/tests/capture_jpeg.py
+++ b/tests/capture_jpeg.py
@@ -2,11 +2,13 @@
 # Capture a JPEG while still running in the preview mode. When you
 # capture to a file, the return value is the metadata for that image.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera, main={"size": (800, 600)})
+preview_config = CameraConfiguration.create_preview_configuration(
+    camera, main={"size": (800, 600)}
+)
 camera.configure(preview_config)
 
 camera.start_preview()

--- a/tests/capture_mjpeg.py
+++ b/tests/capture_mjpeg.py
@@ -3,9 +3,7 @@ from picamera2 import CameraConfig, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(
-    camera, main={"size": (1920, 1080)}
-)
+video_config = CameraConfig.for_video(camera, main={"size": (1920, 1080)})
 camera.configure(video_config)
 
 camera.start_preview()

--- a/tests/capture_mjpeg.py
+++ b/tests/capture_mjpeg.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(
+video_config = CameraConfig.create_video_configuration(
     camera, main={"size": (1920, 1080)}
 )
 camera.configure(video_config)

--- a/tests/capture_mjpeg.py
+++ b/tests/capture_mjpeg.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = camera.create_video_configuration(main={"size": (1920, 1080)})
+video_config = CameraConfiguration.create_video_configuration(camera, main={"size": (1920, 1080)})
 camera.configure(video_config)
 
 camera.start_preview()

--- a/tests/capture_mjpeg.py
+++ b/tests/capture_mjpeg.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(camera, main={"size": (1920, 1080)})
+video_config = CameraConfiguration.create_video_configuration(
+    camera, main={"size": (1920, 1080)}
+)
 camera.configure(video_config)
 
 camera.start_preview()

--- a/tests/capture_mjpeg_v4l2.py
+++ b/tests/capture_mjpeg_v4l2.py
@@ -3,7 +3,7 @@ from picamera2 import CameraConfig, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(camera)
+video_config = CameraConfig.for_video(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_mjpeg_v4l2.py
+++ b/tests/capture_mjpeg_v4l2.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(camera)
+video_config = CameraConfig.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_mjpeg_v4l2.py
+++ b/tests/capture_mjpeg_v4l2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()

--- a/tests/capture_mjpeg_v4l2.py
+++ b/tests/capture_mjpeg_v4l2.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.testing import mature_after_frames_or_timeout
 
 camera = Picamera2()
-video_config = camera.create_video_configuration()
+video_config = CameraConfiguration.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_motion.py
+++ b/tests/capture_motion.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python3
 import numpy as np
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 lsize = (320, 240)
 camera = Picamera2()
-video_config = camera.create_video_configuration(
+video_config = CameraConfiguration.create_video_configuration(
+    camera,
     main={"size": (1280, 720), "format": "RGB888"},
     lores={"size": lsize, "format": "YUV420"},
 )

--- a/tests/capture_motion.py
+++ b/tests/capture_motion.py
@@ -5,7 +5,7 @@ from picamera2 import CameraConfig, Picamera2
 
 lsize = (320, 240)
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(
+video_config = CameraConfig.for_video(
     camera,
     main={"size": (1280, 720), "format": "RGB888"},
     lores={"size": lsize, "format": "YUV420"},

--- a/tests/capture_motion.py
+++ b/tests/capture_motion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import numpy as np
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 lsize = (320, 240)
 camera = Picamera2()

--- a/tests/capture_motion.py
+++ b/tests/capture_motion.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 import numpy as np
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 lsize = (320, 240)
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(
+video_config = CameraConfig.create_video_configuration(
     camera,
     main={"size": (1280, 720), "format": "RGB888"},
     lores={"size": lsize, "format": "YUV420"},

--- a/tests/capture_multiplexer.py
+++ b/tests/capture_multiplexer.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 
 def takephoto(cam):
     camera = Picamera2(camera_num=cam)
-    capture_config = CameraConfiguration.create_still_configuration(camera)
+    capture_config = CameraConfig.create_still_configuration(camera)
     camera.start()
     camera.switch_mode_and_capture_file(capture_config, f"cam{cam}.jpg")
     camera.stop()
@@ -17,7 +17,7 @@ for cam in range(4):
 # Or
 for cam in range(4):
     camera = Picamera2(camera_num=cam)
-    capture_config = CameraConfiguration.create_still_configuration(camera)
+    capture_config = CameraConfig.create_still_configuration(camera)
     camera.start()
     camera.capture_file(f"cam{cam}.jpg", config=capture_config)
     camera.stop()

--- a/tests/capture_multiplexer.py
+++ b/tests/capture_multiplexer.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
-import picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 
 def takephoto(cam):
-    camera = picamera2.Picamera2(camera_num=cam)
-    capture_config = camera.create_still_configuration()
+    camera = Picamera2(camera_num=cam)
+    capture_config = CameraConfiguration.create_still_configuration(camera)
     camera.start()
     camera.switch_mode_and_capture_file(capture_config, f"cam{cam}.jpg")
     camera.stop()
@@ -16,8 +16,8 @@ for cam in range(4):
 
 # Or
 for cam in range(4):
-    camera = picamera2.Picamera2(camera_num=cam)
-    capture_config = camera.create_still_configuration()
+    camera = Picamera2(camera_num=cam)
+    capture_config = CameraConfiguration.create_still_configuration(camera)
     camera.start()
     camera.capture_file(f"cam{cam}.jpg", config=capture_config)
     camera.stop()

--- a/tests/capture_multiplexer.py
+++ b/tests/capture_multiplexer.py
@@ -4,7 +4,7 @@ from picamera2 import CameraConfig, Picamera2
 
 def takephoto(cam):
     camera = Picamera2(camera_num=cam)
-    capture_config = CameraConfig.create_still_configuration(camera)
+    capture_config = CameraConfig.for_still(camera)
     camera.start()
     camera.switch_mode_and_capture_file(capture_config, f"cam{cam}.jpg")
     camera.stop()
@@ -17,7 +17,7 @@ for cam in range(4):
 # Or
 for cam in range(4):
     camera = Picamera2(camera_num=cam)
-    capture_config = CameraConfig.create_still_configuration(camera)
+    capture_config = CameraConfig.for_still(camera)
     camera.start()
     camera.capture_file(f"cam{cam}.jpg", config=capture_config)
     camera.stop()

--- a/tests/capture_multiplexer.py
+++ b/tests/capture_multiplexer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 
 def takephoto(cam):

--- a/tests/capture_png.py
+++ b/tests/capture_png.py
@@ -1,12 +1,14 @@
 #!/usr/bin/python3
 # Capture a PNG while still running in the preview mode.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera, main={"size": (800, 600)})
+preview_config = CameraConfiguration.create_preview_configuration(
+    camera, main={"size": (800, 600)}
+)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_png.py
+++ b/tests/capture_png.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 # Capture a PNG while still running in the preview mode.
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration(main={"size": (800, 600)})
+preview_config = CameraConfiguration.create_preview_configuration(camera, main={"size": (800, 600)})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_png.py
+++ b/tests/capture_png.py
@@ -6,9 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(
-    camera, main={"size": (800, 600)}
-)
+preview_config = CameraConfig.for_preview(camera, main={"size": (800, 600)})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/capture_png.py
+++ b/tests/capture_png.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 # Capture a PNG while still running in the preview mode.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(
+preview_config = CameraConfig.create_preview_configuration(
     camera, main={"size": (800, 600)}
 )
 camera.configure(preview_config)

--- a/tests/capture_to_buffer.py
+++ b/tests/capture_to_buffer.py
@@ -4,7 +4,7 @@ import io
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-camera.configure(CameraConfig.create_preview_configuration(camera))
+camera.configure(CameraConfig.for_preview(camera))
 camera.start()
 
 for i in range(2):

--- a/tests/capture_to_buffer.py
+++ b/tests/capture_to_buffer.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 import io
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-camera.configure(CameraConfiguration.create_preview_configuration(camera))
+camera.configure(CameraConfig.create_preview_configuration(camera))
 camera.start()
 
 for i in range(2):

--- a/tests/capture_to_buffer.py
+++ b/tests/capture_to_buffer.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 import io
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-capture_config = camera.create_still_configuration()
-camera.configure(camera.create_preview_configuration())
+camera.configure(CameraConfiguration.create_preview_configuration(camera))
 camera.start()
 
 for i in range(2):

--- a/tests/capture_to_buffer.py
+++ b/tests/capture_to_buffer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import io
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.configure(CameraConfiguration.create_preview_configuration(camera))

--- a/tests/capture_video.py
+++ b/tests/capture_video.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 video_config = CameraConfiguration.create_video_configuration(camera)

--- a/tests/capture_video.py
+++ b/tests/capture_video.py
@@ -2,7 +2,7 @@
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(camera)
+video_config = CameraConfig.for_video(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_video.py
+++ b/tests/capture_video.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(camera)
+video_config = CameraConfig.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_video.py
+++ b/tests/capture_video.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-video_config = camera.create_video_configuration()
+video_config = CameraConfiguration.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_video_timestamp.py
+++ b/tests/capture_video_timestamp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 video_config = CameraConfiguration.create_video_configuration(camera)

--- a/tests/capture_video_timestamp.py
+++ b/tests/capture_video_timestamp.py
@@ -2,7 +2,7 @@
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(camera)
+video_config = CameraConfig.for_video(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_video_timestamp.py
+++ b/tests/capture_video_timestamp.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(camera)
+video_config = CameraConfig.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/capture_video_timestamp.py
+++ b/tests/capture_video_timestamp.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-video_config = camera.create_video_configuration()
+video_config = CameraConfiguration.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/check_timestamps.py
+++ b/tests/check_timestamps.py
@@ -3,7 +3,7 @@ import time
 
 import numpy as np
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 video_config = CameraConfiguration.create_video_configuration(camera)

--- a/tests/check_timestamps.py
+++ b/tests/check_timestamps.py
@@ -3,10 +3,10 @@ import time
 
 import numpy as np
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-video_config = camera.create_video_configuration()
+video_config = CameraConfiguration.create_video_configuration(camera)
 camera.configure(video_config)
 
 timestamps = []

--- a/tests/check_timestamps.py
+++ b/tests/check_timestamps.py
@@ -3,10 +3,10 @@ import time
 
 import numpy as np
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(camera)
+video_config = CameraConfig.create_video_configuration(camera)
 camera.configure(video_config)
 
 timestamps = []

--- a/tests/check_timestamps.py
+++ b/tests/check_timestamps.py
@@ -6,7 +6,7 @@ import numpy as np
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(camera)
+video_config = CameraConfig.for_video(camera)
 camera.configure(video_config)
 
 timestamps = []

--- a/tests/configurations.py
+++ b/tests/configurations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 def main():
     print("With context...")
     with Picamera2() as camera:
-        config = CameraConfig.create_preview_configuration(camera)
+        config = CameraConfig.for_preview(camera)
         camera.configure(config)
         camera.start()
         metadata = camera.capture_metadata().result()
@@ -15,7 +15,7 @@ def main():
 
     print("Without context...")
     camera = Picamera2()
-    config = CameraConfig.create_preview_configuration(camera)
+    config = CameraConfig.for_preview(camera)
     camera.configure(config)
     camera.start()
     metadata = camera.capture_metadata().result()

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,12 +1,12 @@
 import time
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 
 def main():
     print("With context...")
     with Picamera2() as camera:
-        config = CameraConfiguration.create_preview_configuration(camera)
+        config = CameraConfig.create_preview_configuration(camera)
         camera.configure(config)
         camera.start()
         metadata = camera.capture_metadata().result()
@@ -15,7 +15,7 @@ def main():
 
     print("Without context...")
     camera = Picamera2()
-    config = CameraConfiguration.create_preview_configuration(camera)
+    config = CameraConfig.create_preview_configuration(camera)
     camera.configure(config)
     camera.start()
     metadata = camera.capture_metadata().result()

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,13 +1,13 @@
 import time
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 
 def main():
     print("With context...")
     with Picamera2() as camera:
-        preview = camera.create_preview_configuration()
-        camera.configure(preview)
+        config = CameraConfiguration.create_preview_configuration(camera)
+        camera.configure(config)
         camera.start()
         metadata = camera.capture_metadata().result()
         assert isinstance(metadata, dict)
@@ -15,8 +15,8 @@ def main():
 
     print("Without context...")
     camera = Picamera2()
-    preview = camera.create_preview_configuration()
-    camera.configure(preview)
+    config = CameraConfiguration.create_preview_configuration(camera)
+    camera.configure(config)
     camera.start()
     metadata = camera.capture_metadata().result()
     print(metadata)

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,6 +1,6 @@
 import time
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 
 def main():

--- a/tests/controls.py
+++ b/tests/controls.py
@@ -2,12 +2,12 @@
 
 # Example of setting controls. Here, after one second, we fix the AGC/AEC
 # to the values it has reached whereafter it will no longer change.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls.py
+++ b/tests/controls.py
@@ -2,12 +2,12 @@
 
 # Example of setting controls. Here, after one second, we fix the AGC/AEC
 # to the values it has reached whereafter it will no longer change.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls.py
+++ b/tests/controls.py
@@ -7,7 +7,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls.py
+++ b/tests/controls.py
@@ -2,7 +2,7 @@
 
 # Example of setting controls. Here, after one second, we fix the AGC/AEC
 # to the values it has reached whereafter it will no longer change.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/controls_2.py
+++ b/tests/controls_2.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 # Another (simpler!) way to fix the AEC/AGC and AWB.
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls_2.py
+++ b/tests/controls_2.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls_2.py
+++ b/tests/controls_2.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 # Another (simpler!) way to fix the AEC/AGC and AWB.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls_2.py
+++ b/tests/controls_2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # Another (simpler!) way to fix the AEC/AGC and AWB.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/controls_3.py
+++ b/tests/controls_3.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # Example of setting controls using the "direct" attribute method.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.controls import Controls
 
 camera = Picamera2()

--- a/tests/controls_3.py
+++ b/tests/controls_3.py
@@ -6,7 +6,7 @@ from picamera2.controls import Controls
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls_3.py
+++ b/tests/controls_3.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 # Example of setting controls using the "direct" attribute method.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.controls import Controls
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/controls_3.py
+++ b/tests/controls_3.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 # Example of setting controls using the "direct" attribute method.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.controls import Controls
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -2,11 +2,11 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 print("First preview...")
 camera = Picamera2()
-camera.configure(CameraConfiguration.create_preview_configuration(camera))
+camera.configure(CameraConfig.create_preview_configuration(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()
@@ -15,7 +15,7 @@ print("Done")
 
 print("Second preview...")
 camera = Picamera2()
-camera.configure(CameraConfiguration.create_preview_configuration(camera))
+camera.configure(CameraConfig.create_preview_configuration(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -2,13 +2,11 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-import time
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 print("First preview...")
 camera = Picamera2()
-camera.configure(camera.create_preview_configuration())
+camera.configure(CameraConfiguration.create_preview_configuration(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()
@@ -17,7 +15,7 @@ print("Done")
 
 print("Second preview...")
 camera = Picamera2()
-camera.configure(camera.create_preview_configuration())
+camera.configure(CameraConfiguration.create_preview_configuration(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -2,7 +2,7 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 print("First preview...")
 camera = Picamera2()

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 
 print("First preview...")
 camera = Picamera2()
-camera.configure(CameraConfig.create_preview_configuration(camera))
+camera.configure(CameraConfig.for_preview(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()
@@ -15,7 +15,7 @@ print("Done")
 
 print("Second preview...")
 camera = Picamera2()
-camera.configure(CameraConfig.create_preview_configuration(camera))
+camera.configure(CameraConfig.for_preview(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()

--- a/tests/exposure_fixed.py
+++ b/tests/exposure_fixed.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 # Start camera with fixed exposure and gain.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
-preview_config = camera.create_preview_configuration(controls=controls)
+preview_config = CameraConfiguration.create_preview_configuration(camera, controls=controls)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/exposure_fixed.py
+++ b/tests/exposure_fixed.py
@@ -5,7 +5,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
-preview_config = CameraConfig.create_preview_configuration(camera, controls=controls)
+preview_config = CameraConfig.for_preview(camera, controls=controls)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/exposure_fixed.py
+++ b/tests/exposure_fixed.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 # Start camera with fixed exposure and gain.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
-preview_config = CameraConfiguration.create_preview_configuration(camera, controls=controls)
+preview_config = CameraConfiguration.create_preview_configuration(
+    camera, controls=controls
+)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/exposure_fixed.py
+++ b/tests/exposure_fixed.py
@@ -1,13 +1,11 @@
 #!/usr/bin/python3
 # Start camera with fixed exposure and gain.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
-preview_config = CameraConfiguration.create_preview_configuration(
-    camera, controls=controls
-)
+preview_config = CameraConfig.create_preview_configuration(camera, controls=controls)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # Obtain the current camera control values in the image metadata.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 # Obtain the current camera control values in the image metadata.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 # Obtain the current camera control values in the image metadata.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/metadata_with_image.py
+++ b/tests/metadata_with_image.py
@@ -2,7 +2,7 @@
 
 # Obtain an image from the camera along with the exact metadata that
 # that describes that image.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/metadata_with_image.py
+++ b/tests/metadata_with_image.py
@@ -2,12 +2,12 @@
 
 # Obtain an image from the camera along with the exact metadata that
 # that describes that image.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/metadata_with_image.py
+++ b/tests/metadata_with_image.py
@@ -7,7 +7,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/metadata_with_image.py
+++ b/tests/metadata_with_image.py
@@ -2,12 +2,12 @@
 
 # Obtain an image from the camera along with the exact metadata that
 # that describes that image.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/mode_test.py
+++ b/tests/mode_test.py
@@ -11,7 +11,7 @@ sys.path.append("/usr/lib/python3/dist-packages")
 
 from libcamera import Transform
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.sensor_format import SensorFormat
 
 camera = Picamera2()
@@ -22,7 +22,7 @@ def check(raw_config, fps):
     if raw_config["size"][0] * raw_config["size"][1] > 5e6:
         print("Not checking", raw_config)
         return
-    camera.video_configuration = CameraConfiguration.create_video_configuration(
+    camera.video_configuration = CameraConfig.create_video_configuration(
         camera,
         raw=raw_config,
     )

--- a/tests/mode_test.py
+++ b/tests/mode_test.py
@@ -11,7 +11,7 @@ sys.path.append("/usr/lib/python3/dist-packages")
 
 from libcamera import Transform
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.sensor_format import SensorFormat
 
 camera = Picamera2()
@@ -22,7 +22,8 @@ def check(raw_config, fps):
     if raw_config["size"][0] * raw_config["size"][1] > 5e6:
         print("Not checking", raw_config)
         return
-    camera.video_configuration = camera.create_video_configuration(
+    camera.video_configuration = CameraConfiguration.create_video_configuration(
+        camera,
         raw=raw_config,
     )
     camera.configure("video")

--- a/tests/mode_test.py
+++ b/tests/mode_test.py
@@ -22,7 +22,7 @@ def check(raw_config, fps):
     if raw_config["size"][0] * raw_config["size"][1] > 5e6:
         print("Not checking", raw_config)
         return
-    camera.video_configuration = CameraConfig.create_video_configuration(
+    camera.video_configuration = CameraConfig.for_video(
         camera,
         raw=raw_config,
     )

--- a/tests/mode_test.py
+++ b/tests/mode_test.py
@@ -11,7 +11,7 @@ sys.path.append("/usr/lib/python3/dist-packages")
 
 from libcamera import Transform
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.sensor_format import SensorFormat
 
 camera = Picamera2()

--- a/tests/multicamera.py
+++ b/tests/multicamera.py
@@ -9,11 +9,11 @@ if CameraInfo.n_cameras() <= 1:
     quit()
 
 camera1 = Picamera2(0)
-camera1.configure(CameraConfig.create_preview_configuration(camera1))
+camera1.configure(CameraConfig.for_preview(camera1))
 camera1.start()
 
 camera2 = Picamera2(1)
-camera2.configure(CameraConfig.create_preview_configuration(camera2))
+camera2.configure(CameraConfig.for_preview(camera2))
 camera2.start()
 
 f1 = camera1.discard_frames(4)

--- a/tests/multicamera.py
+++ b/tests/multicamera.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 
-from picamera2 import CameraInfo, Picamera2, CameraConfiguration
-
 import concurrent.futures
+
+from picamera2 import CameraConfiguration, CameraInfo, Picamera2
 
 if CameraInfo.n_cameras() <= 1:
     print("SKIPPED (one camera)")

--- a/tests/multicamera.py
+++ b/tests/multicamera.py
@@ -1,30 +1,34 @@
 #!/usr/bin/python3
 
-import time
+from picamera2 import CameraInfo, Picamera2, CameraConfiguration
 
-from picamera2 import CameraInfo, Picamera2
+import concurrent.futures
 
 if CameraInfo.n_cameras() <= 1:
     print("SKIPPED (one camera)")
     quit()
 
 camera1 = Picamera2(0)
-camera1.configure(camera1.create_preview_configuration())
-camera1.start_preview()
+camera1.configure(CameraConfiguration.create_preview_configuration(camera1))
+camera1.start()
 
 camera2 = Picamera2(1)
-camera2.configure(camera2.create_preview_configuration())
-camera2.start_preview()
-
-camera1.start()
+camera2.configure(CameraConfiguration.create_preview_configuration(camera2))
 camera2.start()
 
-time.sleep(2)
-print(camera1.capture_metadata())
-time.sleep(2)
-print(camera2.capture_metadata())
-camera1.capture_file("testa.jpg").result()
-camera2.capture_file("testb.jpg").result()
+f1 = camera1.discard_frames(4)
+f2 = camera2.discard_frames(4)
+concurrent.futures.wait((f1, f2), timeout=5)
+
+md1 = camera1.capture_metadata()
+md2 = camera2.capture_metadata()
+concurrent.futures.wait((md1, md2), timeout=10)
+print(md1.result())
+print(md2.result())
+
+fi1 = camera1.capture_file("testa.jpg")
+fi2 = camera2.capture_file("testb.jpg")
+concurrent.futures.wait((fi1, fi2), timeout=10)
 
 camera1.stop()
 camera2.stop()

--- a/tests/multicamera.py
+++ b/tests/multicamera.py
@@ -2,18 +2,18 @@
 
 import concurrent.futures
 
-from picamera2 import CameraConfiguration, CameraInfo, Picamera2
+from picamera2 import CameraConfig, CameraInfo, Picamera2
 
 if CameraInfo.n_cameras() <= 1:
     print("SKIPPED (one camera)")
     quit()
 
 camera1 = Picamera2(0)
-camera1.configure(CameraConfiguration.create_preview_configuration(camera1))
+camera1.configure(CameraConfig.create_preview_configuration(camera1))
 camera1.start()
 
 camera2 = Picamera2(1)
-camera2.configure(CameraConfiguration.create_preview_configuration(camera2))
+camera2.configure(CameraConfig.create_preview_configuration(camera2))
 camera2.start()
 
 f1 = camera1.discard_frames(4)

--- a/tests/multicamera_2.py
+++ b/tests/multicamera_2.py
@@ -2,7 +2,7 @@
 
 import time
 
-from picamera2 import CameraInfo, Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, CameraInfo, Picamera2
 
 if CameraInfo.n_cameras() <= 1:
     print("SKIPPED (one camera)")

--- a/tests/multicamera_2.py
+++ b/tests/multicamera_2.py
@@ -9,7 +9,7 @@ if CameraInfo.n_cameras() <= 1:
     quit()
 
 camera1 = Picamera2(0)
-config1 = CameraConfig.create_preview_configuration(camera1)
+config1 = CameraConfig.for_preview(camera1)
 camera1.configure(config1)
 camera1.start_preview()
 camera1.start()
@@ -18,7 +18,7 @@ time.sleep(2)
 camera1.capture_file("testa.jpg").result()
 
 camera2 = Picamera2(1)
-config2 = CameraConfig.create_preview_configuration(camera2)
+config2 = CameraConfig.for_preview(camera2)
 camera2.configure(config2)
 camera2.start()
 

--- a/tests/multicamera_2.py
+++ b/tests/multicamera_2.py
@@ -2,14 +2,15 @@
 
 import time
 
-from picamera2 import CameraInfo, Picamera2
+from picamera2 import CameraInfo, Picamera2, CameraConfiguration
 
 if CameraInfo.n_cameras() <= 1:
     print("SKIPPED (one camera)")
     quit()
 
 camera1 = Picamera2(0)
-camera1.configure(camera1.create_preview_configuration())
+config1 = CameraConfiguration.create_preview_configuration(camera1)
+camera1.configure(config1)
 camera1.start_preview()
 camera1.start()
 
@@ -17,7 +18,8 @@ time.sleep(2)
 camera1.capture_file("testa.jpg").result()
 
 camera2 = Picamera2(1)
-camera2.configure(camera2.create_preview_configuration())
+config2 = CameraConfiguration.create_preview_configuration(camera2)
+camera2.configure(config2)
 camera2.start()
 
 time.sleep(2)

--- a/tests/multicamera_2.py
+++ b/tests/multicamera_2.py
@@ -2,14 +2,14 @@
 
 import time
 
-from picamera2 import CameraConfiguration, CameraInfo, Picamera2
+from picamera2 import CameraConfig, CameraInfo, Picamera2
 
 if CameraInfo.n_cameras() <= 1:
     print("SKIPPED (one camera)")
     quit()
 
 camera1 = Picamera2(0)
-config1 = CameraConfiguration.create_preview_configuration(camera1)
+config1 = CameraConfig.create_preview_configuration(camera1)
 camera1.configure(config1)
 camera1.start_preview()
 camera1.start()
@@ -18,7 +18,7 @@ time.sleep(2)
 camera1.capture_file("testa.jpg").result()
 
 camera2 = Picamera2(1)
-config2 = CameraConfiguration.create_preview_configuration(camera2)
+config2 = CameraConfig.create_preview_configuration(camera2)
 camera2.configure(config2)
 camera2.start()
 

--- a/tests/multicamera_preview.py
+++ b/tests/multicamera_preview.py
@@ -2,14 +2,14 @@
 
 import time
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera1 = Picamera2(0)
-camera1.configure(CameraConfiguration.create_preview_configuration(camera1))
+camera1.configure(CameraConfig.create_preview_configuration(camera1))
 camera1.start_preview()
 
 camera2 = Picamera2(1)
-camera2.configure(CameraConfiguration.create_preview_configuration(camera2))
+camera2.configure(CameraConfig.create_preview_configuration(camera2))
 camera2.start_preview()
 
 camera1.start()

--- a/tests/multicamera_preview.py
+++ b/tests/multicamera_preview.py
@@ -5,11 +5,11 @@ import time
 from picamera2 import CameraConfig, Picamera2
 
 camera1 = Picamera2(0)
-camera1.configure(CameraConfig.create_preview_configuration(camera1))
+camera1.configure(CameraConfig.for_preview(camera1))
 camera1.start_preview()
 
 camera2 = Picamera2(1)
-camera2.configure(CameraConfig.create_preview_configuration(camera2))
+camera2.configure(CameraConfig.for_preview(camera2))
 camera2.start_preview()
 
 camera1.start()

--- a/tests/multicamera_preview.py
+++ b/tests/multicamera_preview.py
@@ -2,16 +2,14 @@
 
 import time
 
-import numpy as np
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera1 = Picamera2(0)
-camera1.configure(camera1.create_preview_configuration())
+camera1.configure(CameraConfiguration.create_preview_configuration(camera1))
 camera1.start_preview()
 
 camera2 = Picamera2(1)
-camera2.configure(camera2.create_preview_configuration())
+camera2.configure(CameraConfiguration.create_preview_configuration(camera2))
 camera2.start_preview()
 
 camera1.start()

--- a/tests/multicamera_preview.py
+++ b/tests/multicamera_preview.py
@@ -2,7 +2,7 @@
 
 import time
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera1 = Picamera2(0)
 camera1.configure(CameraConfiguration.create_preview_configuration(camera1))

--- a/tests/multiple_quality_capture.py
+++ b/tests/multiple_quality_capture.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 video_config = CameraConfiguration.create_video_configuration(camera)

--- a/tests/multiple_quality_capture.py
+++ b/tests/multiple_quality_capture.py
@@ -2,7 +2,7 @@
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfig.create_video_configuration(camera)
+video_config = CameraConfig.for_video(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/multiple_quality_capture.py
+++ b/tests/multiple_quality_capture.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-video_config = CameraConfiguration.create_video_configuration(camera)
+video_config = CameraConfig.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/multiple_quality_capture.py
+++ b/tests/multiple_quality_capture.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-video_config = camera.create_video_configuration()
+video_config = CameraConfiguration.create_video_configuration(camera)
 camera.configure(video_config)
 
 camera.start()

--- a/tests/pick_mode.py
+++ b/tests/pick_mode.py
@@ -2,7 +2,7 @@
 
 # Example of reading the available modes, and picking one with
 # the highest framerate and a raw bit depth of at least 10
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 
@@ -15,7 +15,7 @@ available_modes.sort(key=lambda x: x["fps"], reverse=True)
 [print(i) for i in available_modes]
 chosen_mode = available_modes[0]
 
-camera.video_configuration = CameraConfiguration.create_video_configuration(
+camera.video_configuration = CameraConfig.create_video_configuration(
     camera, raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
 )
 camera.configure("video")

--- a/tests/pick_mode.py
+++ b/tests/pick_mode.py
@@ -2,7 +2,7 @@
 
 # Example of reading the available modes, and picking one with
 # the highest framerate and a raw bit depth of at least 10
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 
@@ -15,7 +15,8 @@ available_modes.sort(key=lambda x: x["fps"], reverse=True)
 [print(i) for i in available_modes]
 chosen_mode = available_modes[0]
 
-camera.video_configuration = camera.create_video_configuration(
+camera.video_configuration = CameraConfiguration.create_video_configuration(
+    camera,
     raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
 )
 camera.configure("video")

--- a/tests/pick_mode.py
+++ b/tests/pick_mode.py
@@ -2,7 +2,7 @@
 
 # Example of reading the available modes, and picking one with
 # the highest framerate and a raw bit depth of at least 10
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 
@@ -16,8 +16,7 @@ available_modes.sort(key=lambda x: x["fps"], reverse=True)
 chosen_mode = available_modes[0]
 
 camera.video_configuration = CameraConfiguration.create_video_configuration(
-    camera,
-    raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
+    camera, raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
 )
 camera.configure("video")
 

--- a/tests/pick_mode.py
+++ b/tests/pick_mode.py
@@ -15,7 +15,7 @@ available_modes.sort(key=lambda x: x["fps"], reverse=True)
 [print(i) for i in available_modes]
 chosen_mode = available_modes[0]
 
-camera.video_configuration = CameraConfig.create_video_configuration(
+camera.video_configuration = CameraConfig.for_video(
     camera, raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
 )
 camera.configure("video")

--- a/tests/preview.py
+++ b/tests/preview.py
@@ -5,12 +5,12 @@
 
 import time
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview.py
+++ b/tests/preview.py
@@ -5,7 +5,7 @@
 
 import time
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/preview.py
+++ b/tests/preview.py
@@ -5,12 +5,12 @@
 
 import time
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview.py
+++ b/tests/preview.py
@@ -10,7 +10,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_drm.py
+++ b/tests/preview_drm.py
@@ -1,14 +1,12 @@
 #!/usr/bin/python3
 
 # For use from the login console, when not running X Windows.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(
-    camera, {"size": (640, 360)}
-)
+preview_config = CameraConfig.create_preview_configuration(camera, {"size": (640, 360)})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_drm.py
+++ b/tests/preview_drm.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera, {"size": (640, 360)})
+preview_config = CameraConfig.for_preview(camera, {"size": (640, 360)})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_drm.py
+++ b/tests/preview_drm.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 # For use from the login console, when not running X Windows.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration({"size": (640, 360)})
+preview_config = CameraConfiguration.create_preview_configuration(camera, {"size": (640, 360)})
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_drm.py
+++ b/tests/preview_drm.py
@@ -1,12 +1,14 @@
 #!/usr/bin/python3
 
 # For use from the login console, when not running X Windows.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera, {"size": (640, 360)})
+preview_config = CameraConfiguration.create_preview_configuration(
+    camera, {"size": (640, 360)}
+)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -7,7 +7,7 @@ from picamera2 import CameraConfig, Picamera2
 _log = getLogger(__name__)
 _log.info("Preview re-initialized after start.")
 camera = Picamera2()
-preview = CameraConfig.create_preview_configuration(camera)
+preview = CameraConfig.for_preview(camera)
 camera.configure(preview)
 camera.start()
 np_array = camera.capture_array().result()

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -1,13 +1,11 @@
 from logging import getLogger
-
 import numpy as np
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 _log = getLogger(__name__)
 _log.info("Preview re-initialized after start.")
 camera = Picamera2()
-preview = camera.create_preview_configuration()
+preview = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview)
 camera.start()
 np_array = camera.capture_array().result()

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -2,12 +2,12 @@ from logging import getLogger
 
 import numpy as np
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 _log = getLogger(__name__)
 _log.info("Preview re-initialized after start.")
 camera = Picamera2()
-preview = CameraConfiguration.create_preview_configuration(camera)
+preview = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview)
 camera.start()
 np_array = camera.capture_array().result()

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -1,6 +1,8 @@
 from logging import getLogger
+
 import numpy as np
-from picamera2 import Picamera2, CameraConfiguration
+
+from picamera2 import CameraConfiguration, Picamera2
 
 _log = getLogger(__name__)
 _log.info("Preview re-initialized after start.")

--- a/tests/preview_null.py
+++ b/tests/preview_null.py
@@ -3,7 +3,7 @@
 from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-config = CameraConfig.create_preview_configuration(camera)
+config = CameraConfig.for_preview(camera)
 camera.configure(config)
 
 camera.start()

--- a/tests/preview_null.py
+++ b/tests/preview_null.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 config = CameraConfiguration.create_preview_configuration(camera)

--- a/tests/preview_null.py
+++ b/tests/preview_null.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
-config = CameraConfiguration.create_preview_configuration(camera)
+config = CameraConfig.create_preview_configuration(camera)
 camera.configure(config)
 
 camera.start()

--- a/tests/preview_null.py
+++ b/tests/preview_null.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
-config = camera.create_preview_configuration()
+config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(config)
 
 camera.start()

--- a/tests/preview_x_forwarding.py
+++ b/tests/preview_x_forwarding.py
@@ -3,7 +3,7 @@
 # The QtPreview uses software rendering and thus makes more use of the
 # CPU, but it does work with X forwarding, unlike the QtGlPreview.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/preview_x_forwarding.py
+++ b/tests/preview_x_forwarding.py
@@ -3,12 +3,12 @@
 # The QtPreview uses software rendering and thus makes more use of the
 # CPU, but it does work with X forwarding, unlike the QtGlPreview.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_x_forwarding.py
+++ b/tests/preview_x_forwarding.py
@@ -8,7 +8,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/preview_x_forwarding.py
+++ b/tests/preview_x_forwarding.py
@@ -3,14 +3,12 @@
 # The QtPreview uses software rendering and thus makes more use of the
 # CPU, but it does work with X forwarding, unlike the QtGlPreview.
 
-import time
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 for i in range(2):
     print(f"{i} preview...")

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -1,15 +1,12 @@
 #!/usr/bin/python3
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
-
-import time
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 for i in range(2):
     print(f"{i} preview...")
     camera = Picamera2()
-    camera.configure(camera.create_preview_configuration())
+    camera.configure(CameraConfiguration.create_preview_configuration(camera))
     camera.start_preview()
     camera.start()
     camera.discard_frames(5).result()

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 for i in range(2):
     print(f"{i} preview...")
     camera = Picamera2()
-    camera.configure(CameraConfig.create_preview_configuration(camera))
+    camera.configure(CameraConfig.for_preview(camera))
     camera.start_preview()
     camera.start()
     camera.discard_frames(5).result()

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 for i in range(2):
     print(f"{i} preview...")
     camera = Picamera2()
-    camera.configure(CameraConfiguration.create_preview_configuration(camera))
+    camera.configure(CameraConfig.create_preview_configuration(camera))
     camera.start_preview()
     camera.start()
     camera.discard_frames(5).result()

--- a/tests/raw.py
+++ b/tests/raw.py
@@ -6,7 +6,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(
+preview_config = CameraConfig.for_preview(
     camera, raw={"size": camera.sensor_resolution, "format": camera.sensor_format}
 )
 print(preview_config)

--- a/tests/raw.py
+++ b/tests/raw.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python3
 
 # Configure a raw stream and capture an image from it.
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration(
+preview_config = CameraConfiguration.create_preview_configuration(
+    camera,
     raw={"size": camera.sensor_resolution, "format": camera.sensor_format}
 )
 print(preview_config)

--- a/tests/raw.py
+++ b/tests/raw.py
@@ -1,14 +1,13 @@
 #!/usr/bin/python3
 
 # Configure a raw stream and capture an image from it.
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
 preview_config = CameraConfiguration.create_preview_configuration(
-    camera,
-    raw={"size": camera.sensor_resolution, "format": camera.sensor_format}
+    camera, raw={"size": camera.sensor_resolution, "format": camera.sensor_format}
 )
 print(preview_config)
 

--- a/tests/raw.py
+++ b/tests/raw.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 # Configure a raw stream and capture an image from it.
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(
+preview_config = CameraConfig.create_preview_configuration(
     camera, raw={"size": camera.sensor_resolution, "format": camera.sensor_format}
 )
 print(preview_config)

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -6,12 +6,12 @@ import sys
 sys.path.append("/usr/lib/python3/dist-packages")
 import libcamera
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 preview_config.transform = libcamera.Transform(hflip=1, vflip=1)
 camera.configure(preview_config)
 

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -6,12 +6,12 @@ import sys
 sys.path.append("/usr/lib/python3/dist-packages")
 import libcamera
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 preview_config.transform = libcamera.Transform(hflip=1, vflip=1)
 camera.configure(preview_config)
 

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -6,7 +6,7 @@ import sys
 sys.path.append("/usr/lib/python3/dist-packages")
 import libcamera
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -11,7 +11,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 preview_config.transform = libcamera.Transform(hflip=1, vflip=1)
 camera.configure(preview_config)
 

--- a/tests/stack_processed.py
+++ b/tests/stack_processed.py
@@ -29,9 +29,7 @@ gamma_lut = np.interp(range(num_frames * 255 + 1), gamma_x, gamma_y, right=255).
 )
 
 camera = Picamera2(tuning=tuning)
-config = CameraConfig.create_still_configuration(
-    camera, {"format": "RGB888"}, buffer_count=2
-)
+config = CameraConfig.for_still(camera, {"format": "RGB888"}, buffer_count=2)
 camera.configure(config)
 images = []
 camera.set_controls({"ExposureTime": exposure_time // num_frames, "AnalogueGain": 1.0})

--- a/tests/stack_processed.py
+++ b/tests/stack_processed.py
@@ -8,7 +8,7 @@
 import numpy as np
 from PIL import Image
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 exposure_time = 60000  # put your own numbers here
 num_frames = 6
@@ -29,7 +29,9 @@ gamma_lut = np.interp(range(num_frames * 255 + 1), gamma_x, gamma_y, right=255).
 )
 
 camera = Picamera2(tuning=tuning)
-config = CameraConfiguration.create_still_configuration(camera, {"format": "RGB888"}, buffer_count=2)
+config = CameraConfiguration.create_still_configuration(
+    camera, {"format": "RGB888"}, buffer_count=2
+)
 camera.configure(config)
 images = []
 camera.set_controls({"ExposureTime": exposure_time // num_frames, "AnalogueGain": 1.0})

--- a/tests/stack_processed.py
+++ b/tests/stack_processed.py
@@ -8,7 +8,7 @@
 import numpy as np
 from PIL import Image
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 exposure_time = 60000  # put your own numbers here
 num_frames = 6
@@ -29,7 +29,7 @@ gamma_lut = np.interp(range(num_frames * 255 + 1), gamma_x, gamma_y, right=255).
 )
 
 camera = Picamera2(tuning=tuning)
-config = CameraConfiguration.create_still_configuration(
+config = CameraConfig.create_still_configuration(
     camera, {"format": "RGB888"}, buffer_count=2
 )
 camera.configure(config)

--- a/tests/stack_processed.py
+++ b/tests/stack_processed.py
@@ -8,7 +8,7 @@
 import numpy as np
 from PIL import Image
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 exposure_time = 60000  # put your own numbers here
 num_frames = 6
@@ -29,7 +29,7 @@ gamma_lut = np.interp(range(num_frames * 255 + 1), gamma_x, gamma_y, right=255).
 )
 
 camera = Picamera2(tuning=tuning)
-config = camera.create_still_configuration({"format": "RGB888"}, buffer_count=2)
+config = CameraConfiguration.create_still_configuration(camera, {"format": "RGB888"}, buffer_count=2)
 camera.configure(config)
 images = []
 camera.set_controls({"ExposureTime": exposure_time // num_frames, "AnalogueGain": 1.0})

--- a/tests/stack_raw.py
+++ b/tests/stack_raw.py
@@ -8,9 +8,9 @@
 import numpy as np
 from PIL import Image
 
-from picamera2 import Picamera2
-from picamera2.request import Helpers
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.sensor_format import SensorFormat
+
 
 exposure_time = 60000
 num_frames = 6
@@ -19,7 +19,8 @@ num_frames = 6
 camera = Picamera2()
 raw_format = SensorFormat(camera.sensor_format)
 raw_format.packing = None
-config = camera.create_still_configuration(
+config = CameraConfiguration.create_still_configuration(
+    camera,
     raw={"format": raw_format.format}, buffer_count=2
 )
 camera.configure(config)

--- a/tests/stack_raw.py
+++ b/tests/stack_raw.py
@@ -8,9 +8,8 @@
 import numpy as np
 from PIL import Image
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.sensor_format import SensorFormat
-
 
 exposure_time = 60000
 num_frames = 6
@@ -20,8 +19,7 @@ camera = Picamera2()
 raw_format = SensorFormat(camera.sensor_format)
 raw_format.packing = None
 config = CameraConfiguration.create_still_configuration(
-    camera,
-    raw={"format": raw_format.format}, buffer_count=2
+    camera, raw={"format": raw_format.format}, buffer_count=2
 )
 camera.configure(config)
 images = []

--- a/tests/stack_raw.py
+++ b/tests/stack_raw.py
@@ -18,7 +18,7 @@ num_frames = 6
 camera = Picamera2()
 raw_format = SensorFormat(camera.sensor_format)
 raw_format.packing = None
-config = CameraConfig.create_still_configuration(
+config = CameraConfig.for_still(
     camera, raw={"format": raw_format.format}, buffer_count=2
 )
 camera.configure(config)

--- a/tests/stack_raw.py
+++ b/tests/stack_raw.py
@@ -8,7 +8,7 @@
 import numpy as np
 from PIL import Image
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.sensor_format import SensorFormat
 
 exposure_time = 60000
@@ -18,7 +18,7 @@ num_frames = 6
 camera = Picamera2()
 raw_format = SensorFormat(camera.sensor_format)
 raw_format.packing = None
-config = CameraConfiguration.create_still_configuration(
+config = CameraConfig.create_still_configuration(
     camera, raw={"format": raw_format.format}, buffer_count=2
 )
 camera.configure(config)

--- a/tests/still_during_video.py
+++ b/tests/still_during_video.py
@@ -8,9 +8,7 @@ camera = Picamera2()
 half_resolution = tuple(dim // 2 for dim in camera.sensor_resolution)
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = CameraConfig.create_video_configuration(
-    camera, main=main_stream, lores=lores_stream
-)
+video_config = CameraConfig.for_video(camera, main=main_stream, lores=lores_stream)
 camera.configure(video_config)
 camera.start()
 

--- a/tests/still_during_video.py
+++ b/tests/still_during_video.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 from picamera2.request import CompletedRequest
 
 # Encode a VGA stream, and capture a higher resolution still image half way through.
@@ -8,7 +8,7 @@ camera = Picamera2()
 half_resolution = tuple(dim // 2 for dim in camera.sensor_resolution)
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = CameraConfiguration.create_video_configuration(
+video_config = CameraConfig.create_video_configuration(
     camera, main=main_stream, lores=lores_stream
 )
 camera.configure(video_config)

--- a/tests/still_during_video.py
+++ b/tests/still_during_video.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 from picamera2.request import CompletedRequest
 
 # Encode a VGA stream, and capture a higher resolution still image half way through.
@@ -8,7 +8,7 @@ camera = Picamera2()
 half_resolution = tuple(dim // 2 for dim in camera.sensor_resolution)
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = camera.create_video_configuration(main=main_stream, lores=lores_stream)
+video_config = CameraConfiguration.create_video_configuration(camera, main=main_stream, lores=lores_stream)
 camera.configure(video_config)
 camera.start()
 

--- a/tests/still_during_video.py
+++ b/tests/still_during_video.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 from picamera2.request import CompletedRequest
 
 # Encode a VGA stream, and capture a higher resolution still image half way through.
@@ -8,7 +8,9 @@ camera = Picamera2()
 half_resolution = tuple(dim // 2 for dim in camera.sensor_resolution)
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = CameraConfiguration.create_video_configuration(camera, main=main_stream, lores=lores_stream)
+video_config = CameraConfiguration.create_video_configuration(
+    camera, main=main_stream, lores=lores_stream
+)
 camera.configure(video_config)
 camera.start()
 

--- a/tests/switch_mode.py
+++ b/tests/switch_mode.py
@@ -7,12 +7,12 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(4)
-other_config = CameraConfig.create_preview_configuration(
+other_config = CameraConfig.for_preview(
     camera, main={"size": camera.sensor_resolution}, buffer_count=3
 )
 

--- a/tests/switch_mode.py
+++ b/tests/switch_mode.py
@@ -2,19 +2,18 @@
 
 # Switch from preview to full resolution mode.
 
-import time
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(4)
-other_config = camera.create_preview_configuration(
+other_config = CameraConfiguration.create_preview_configuration(
+    camera,
     main={"size": camera.sensor_resolution}, buffer_count=3
 )
 

--- a/tests/switch_mode.py
+++ b/tests/switch_mode.py
@@ -2,17 +2,17 @@
 
 # Switch from preview to full resolution mode.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(4)
-other_config = CameraConfiguration.create_preview_configuration(
+other_config = CameraConfig.create_preview_configuration(
     camera, main={"size": camera.sensor_resolution}, buffer_count=3
 )
 

--- a/tests/switch_mode.py
+++ b/tests/switch_mode.py
@@ -2,7 +2,7 @@
 
 # Switch from preview to full resolution mode.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
@@ -13,8 +13,7 @@ camera.configure(preview_config)
 camera.start()
 camera.discard_frames(4)
 other_config = CameraConfiguration.create_preview_configuration(
-    camera,
-    main={"size": camera.sensor_resolution}, buffer_count=3
+    camera, main={"size": camera.sensor_resolution}, buffer_count=3
 )
 
 camera.switch_mode(other_config)

--- a/tests/switch_mode_2.py
+++ b/tests/switch_mode_2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # Switch from preview to full resolution mode (alternative method).
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
@@ -14,8 +14,7 @@ camera.discard_frames(4)
 camera.stop()
 
 other_config = CameraConfiguration.create_preview_configuration(
-    camera,
-    main={"size": camera.sensor_resolution}, buffer_count=3
+    camera, main={"size": camera.sensor_resolution}, buffer_count=3
 )
 camera.configure(other_config)
 

--- a/tests/switch_mode_2.py
+++ b/tests/switch_mode_2.py
@@ -6,14 +6,14 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(4)
 camera.stop()
 
-other_config = CameraConfig.create_preview_configuration(
+other_config = CameraConfig.for_preview(
     camera, main={"size": camera.sensor_resolution}, buffer_count=3
 )
 camera.configure(other_config)

--- a/tests/switch_mode_2.py
+++ b/tests/switch_mode_2.py
@@ -1,19 +1,19 @@
 #!/usr/bin/python3
 
 # Switch from preview to full resolution mode (alternative method).
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(4)
 camera.stop()
 
-other_config = CameraConfiguration.create_preview_configuration(
+other_config = CameraConfig.create_preview_configuration(
     camera, main={"size": camera.sensor_resolution}, buffer_count=3
 )
 camera.configure(other_config)

--- a/tests/switch_mode_2.py
+++ b/tests/switch_mode_2.py
@@ -1,22 +1,20 @@
 #!/usr/bin/python3
 
 # Switch from preview to full resolution mode (alternative method).
-
-import time
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(4)
 camera.stop()
 
-other_config = camera.create_preview_configuration(
+other_config = CameraConfiguration.create_preview_configuration(
+    camera,
     main={"size": camera.sensor_resolution}, buffer_count=3
 )
 camera.configure(other_config)

--- a/tests/tuning_file.py
+++ b/tests/tuning_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 # Here we load up the tuning for the HQ cam and alter the default exposure profile.
 # For more information on what can be changed, see chapter 5 in
@@ -10,7 +10,7 @@ algo = Picamera2.find_tuning_algo(tuning, "rpi.agc")
 algo["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
 
 camera = Picamera2(tuning=tuning)
-camera.configure(CameraConfiguration.create_preview_configuration(camera))
+camera.configure(CameraConfig.create_preview_configuration(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()

--- a/tests/tuning_file.py
+++ b/tests/tuning_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 # Here we load up the tuning for the HQ cam and alter the default exposure profile.
 # For more information on what can be changed, see chapter 5 in

--- a/tests/tuning_file.py
+++ b/tests/tuning_file.py
@@ -10,7 +10,7 @@ algo = Picamera2.find_tuning_algo(tuning, "rpi.agc")
 algo["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
 
 camera = Picamera2(tuning=tuning)
-camera.configure(CameraConfig.create_preview_configuration(camera))
+camera.configure(CameraConfig.for_preview(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()

--- a/tests/tuning_file.py
+++ b/tests/tuning_file.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
-import time
-
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 # Here we load up the tuning for the HQ cam and alter the default exposure profile.
 # For more information on what can be changed, see chapter 5 in
@@ -12,7 +10,7 @@ algo = Picamera2.find_tuning_algo(tuning, "rpi.agc")
 algo["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
 
 camera = Picamera2(tuning=tuning)
-camera.configure(camera.create_preview_configuration())
+camera.configure(CameraConfiguration.create_preview_configuration(camera))
 camera.start_preview()
 camera.start()
 camera.discard_frames(2).result()

--- a/tests/zoom.py
+++ b/tests/zoom.py
@@ -2,12 +2,12 @@
 
 # How to do digital zoom using the "ScalerCrop" control.
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, CameraConfiguration
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = camera.create_preview_configuration()
+preview_config = CameraConfiguration.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/zoom.py
+++ b/tests/zoom.py
@@ -2,12 +2,12 @@
 
 # How to do digital zoom using the "ScalerCrop" control.
 
-from picamera2 import CameraConfiguration, Picamera2
+from picamera2 import CameraConfig, Picamera2
 
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfiguration.create_preview_configuration(camera)
+preview_config = CameraConfig.create_preview_configuration(camera)
 camera.configure(preview_config)
 
 camera.start()

--- a/tests/zoom.py
+++ b/tests/zoom.py
@@ -2,7 +2,7 @@
 
 # How to do digital zoom using the "ScalerCrop" control.
 
-from picamera2 import Picamera2, CameraConfiguration
+from picamera2 import CameraConfiguration, Picamera2
 
 camera = Picamera2()
 camera.start_preview()

--- a/tests/zoom.py
+++ b/tests/zoom.py
@@ -7,7 +7,7 @@ from picamera2 import CameraConfig, Picamera2
 camera = Picamera2()
 camera.start_preview()
 
-preview_config = CameraConfig.create_preview_configuration(camera)
+preview_config = CameraConfig.for_preview(camera)
 camera.configure(preview_config)
 
 camera.start()


### PR DESCRIPTION
This diff looks big, but really it just renames the classes to somethign shorter and moves the config builder subroutines off the picamera2 object.