### PR TITLE
Cleanup Several `__init__` deficiencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Poetry Install Deps
         run: poetry install
       - name: Test
-        run: bash test.sh 
+        run: PYTHONPATH=/usr/lib/python3/dist-packages bash test.sh

--- a/scicamera/__init__.py
+++ b/scicamera/__init__.py
@@ -2,7 +2,7 @@ import importlib.metadata
 
 import libcamera
 
-from scicamera.camera import Camera
+from scicamera.camera import Camera, CameraManager
 from scicamera.configuration import CameraConfig, StreamConfig
 from scicamera.controls import Controls
 from scicamera.fake import FakeCamera
@@ -20,7 +20,9 @@ libcamera.ColorSpace.__eq__ = libcamera_color_spaces_eq
 __all__ = [
     "Camera",
     "CameraConfig",
-    "CameraInfo" "CompletedRequest",
+    "CameraInfo",
+    "CameraManager",
+    "CompletedRequest",
     "Controls",
     "FakeCamera",
     "StreamConfig",

--- a/scicamera/__init__.py
+++ b/scicamera/__init__.py
@@ -3,10 +3,10 @@ import importlib.metadata
 import libcamera
 
 from scicamera.camera import Camera
-from scicamera.info import CameraInfo
 from scicamera.configuration import CameraConfig, StreamConfig
 from scicamera.controls import Controls
 from scicamera.fake import FakeCamera
+from scicamera.info import CameraInfo
 from scicamera.lc_helpers import libcamera_color_spaces_eq, libcamera_transforms_eq
 
 # NOTE(meawoppl) - ugleeee monkey patch. Kill the below VV
@@ -20,8 +20,7 @@ libcamera.ColorSpace.__eq__ = libcamera_color_spaces_eq
 __all__ = [
     "Camera",
     "CameraConfig",
-    "CameraInfo"
-    "CompletedRequest",
+    "CameraInfo" "CompletedRequest",
     "Controls",
     "FakeCamera",
     "StreamConfig",

--- a/scicamera/__init__.py
+++ b/scicamera/__init__.py
@@ -1,15 +1,13 @@
 import importlib.metadata
-import sys
 
-sys.path.append("/usr/lib/python3/dist-packages")
 import libcamera
 
-from scicamera.camera import Camera, CameraInfo
+from scicamera.camera import Camera
+from scicamera.info import CameraInfo
 from scicamera.configuration import CameraConfig, StreamConfig
 from scicamera.controls import Controls
-from scicamera.converters import YUV420_to_RGB
+from scicamera.fake import FakeCamera
 from scicamera.lc_helpers import libcamera_color_spaces_eq, libcamera_transforms_eq
-from scicamera.request import CompletedRequest
 
 # NOTE(meawoppl) - ugleeee monkey patch. Kill the below VV
 libcamera.Transform.__repr__ = libcamera.Transform.__str__
@@ -20,13 +18,13 @@ libcamera.ColorSpace.__eq__ = libcamera_color_spaces_eq
 
 
 __all__ = [
-    "CameraConfig",
-    "StreamConfig",
-    "Controls",
-    "YUV420_to_RGB",
     "Camera",
-    "CameraInfo",
+    "CameraConfig",
+    "CameraInfo"
     "CompletedRequest",
+    "Controls",
+    "FakeCamera",
+    "StreamConfig",
 ]
 
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/tests/old/close_test_multiple.py
+++ b/tests/old/close_test_multiple.py
@@ -17,7 +17,6 @@ def run_camera(idx):
 
 
 if __name__ == "__main__":
-
     if CameraInfo.n_cameras() <= 1:
         print("SKIPPED (one camera)")
         quit()


### PR DESCRIPTION
This is a grab bag of small stuff. The `__init__` in the main module exposed a bunch of esoteric and unused stuff. I sorted and titied that. I also added `__init__.py` instances for the test folders which are grumpy on my older install for some reason I can't grock having to do with how pytest handles imports in some version cross section...