### PR TITLE
Rearrange the `CameraFrame` output formats

### DIFF
--- a/scicamera/fake.py
+++ b/scicamera/fake.py
@@ -75,7 +75,6 @@ class FakeCamera(RequestMachinery):
         self._t.join()
         self._abort = Event()
 
-
         self.sensor_resolution = FAKE_SIZE
         self.camera_config = None
         self.camera_ctrl_info = {
@@ -98,7 +97,6 @@ class FakeCamera(RequestMachinery):
             color_space=libcamera.ColorSpace.Sycc(),
             main=StreamConfig(size=FAKE_SIZE, format=FAKE_FORMAT, stride=FAKE_STRIDE),
         )
-
 
     def _run(self):
         while not self._abort.wait(0.1):

--- a/scicamera/fake.py
+++ b/scicamera/fake.py
@@ -75,15 +75,6 @@ class FakeCamera(RequestMachinery):
         self._t.join()
         self._abort = Event()
 
-        self.config = CameraConfig(
-            self,
-            "still",
-            1,
-            controls={},
-            transform=libcamera.Transform(),
-            color_space=libcamera.ColorSpace.Sycc(),
-            main=StreamConfig(size=FAKE_SIZE, format=FAKE_FORMAT, stride=FAKE_STRIDE),
-        )
 
         self.sensor_resolution = FAKE_SIZE
         self.camera_config = None
@@ -97,6 +88,17 @@ class FakeCamera(RequestMachinery):
             "NoiseReductionMode": 0,
         }
         self.controls = Controls(self, self.camera_ctrl_info)
+
+        self.config = CameraConfig(
+            self,
+            "still",
+            1,
+            controls=self.controls,
+            transform=libcamera.Transform(),
+            color_space=libcamera.ColorSpace.Sycc(),
+            main=StreamConfig(size=FAKE_SIZE, format=FAKE_FORMAT, stride=FAKE_STRIDE),
+        )
+
 
     def _run(self):
         while not self._abort.wait(0.1):

--- a/scicamera/frame.py
+++ b/scicamera/frame.py
@@ -12,7 +12,7 @@ class CameraFrame:
     array: np.ndarray
     """The image data as a numpy array."""
 
-    config: dict
+    controls: dict
     """The configuration used to capture the image."""
 
     metadata: dict
@@ -23,6 +23,6 @@ class CameraFrame:
         """Create a CameraFrame from a CompletedRequest."""
         return cls(
             array=request.make_array(name),
+            controls=request.config.controls.make_dict(),
             metadata=request.get_metadata(),
-            config=request.config,
         )

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -25,4 +25,4 @@ def test_capture_multi_frame(CameraClass: Type[Camera]):
         frame = f.result()
         assert isinstance(f, Future), type(f)
         assert isinstance(frame, CameraFrame), type(frame)
-        assert "ExposureTime" in frame.controls, frame.controls
+        assert "FrameDurationLimits" in frame.controls, frame.controls

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -17,7 +17,6 @@ def test_capture_multi_frame(CameraClass: Type[Camera]):
     futures = camera.capture_serial_frames(5)
     wait(futures, timeout=10)
 
-
     camera.stop()
     camera.close()
 

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -20,6 +20,6 @@ def test_capture_multi_frame(CameraClass: Type[Camera]):
 
     for f in futures:
         frame = f.result()
-        assert isinstance(f, Future)
-        assert isinstance(frame, CameraFrame)
-        assert frame.controls["ExposureTime"] is not None
+        assert isinstance(f, Future), type(f)
+        assert isinstance(frame, CameraFrame), type(frame)
+        assert "ExposureTime" in frame.controls, frame.controls

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -19,5 +19,7 @@ def test_capture_multi_frame(CameraClass: Type[Camera]):
     camera.close()
 
     for f in futures:
+        frame = f.result()
         assert isinstance(f, Future)
-        assert isinstance(f.result(), CameraFrame)
+        assert isinstance(frame, CameraFrame)
+        assert frame.controls["ExposureTime"] is not None

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -15,6 +15,8 @@ def test_capture_multi_frame(CameraClass: Type[Camera]):
     futures = camera.capture_serial_frames(5)
     wait(futures, timeout=10)
 
+    camera.controls.ExposureTime = 10000
+
     camera.stop()
     camera.close()
 

--- a/tests/test_multi_frame.py
+++ b/tests/test_multi_frame.py
@@ -12,10 +12,11 @@ def test_capture_multi_frame(CameraClass: Type[Camera]):
     camera = CameraClass()
 
     camera.start()
+    camera.controls.ExposureTime = 10000
+    camera.discard_frames(2).result(0.5)
     futures = camera.capture_serial_frames(5)
     wait(futures, timeout=10)
 
-    camera.controls.ExposureTime = 10000
 
     camera.stop()
     camera.close()


### PR DESCRIPTION
Small tweaks to the output formats for `CameraFrame` to make it more useful/portable.