### PR TITLE
Move the `CameraManager.singleton()` into `Camera.__init__()`

### DIFF
--- a/scicamera/camera.py
+++ b/scicamera/camera.py
@@ -147,7 +147,7 @@ class Camera(RequestMachinery):
 
     @property
     def camera_manager(self):
-        return Camera._cm.cms
+        return self._cm.cms
 
     def _reset_flags(self) -> None:
         self.camera = None

--- a/scicamera/camera.py
+++ b/scicamera/camera.py
@@ -120,8 +120,6 @@ class CameraManager:
 class Camera(RequestMachinery):
     """Welcome to the Camera class."""
 
-    _cm = CameraManager()
-
     def __init__(self, camera_num: int = 0, tuning=None):
         """Initialise camera system and open the camera for use.
 
@@ -132,6 +130,7 @@ class Camera(RequestMachinery):
         :raises RuntimeError: Init didn't complete
         """
         super().__init__()
+        self._cm = CameraManager.singleton()
 
         self._cm.add(camera_num, self)
         self.camera_idx = camera_num


### PR DESCRIPTION
If there aren't any connected cameras, the current build will fail on `from scicamera.camera import Camera` because the static methods will be initialized at that time.

This will also likely speed up testing of fake devices, as there isn't a round trip into the linked C-lib unless it is actually called.