### PR TITLE
Move Config Methods onto `CameraConfig` class

### DIFF
--- a/scicamera/actions.py
+++ b/scicamera/actions.py
@@ -118,7 +118,7 @@ class RequestMachinery:
 
     def _switch_mode(self, camera_config):
         self._stop()
-        self._configure(camera_config)
+        self.configure(camera_config)
         self._start()
         return self.camera_config
 

--- a/scicamera/camera.py
+++ b/scicamera/camera.py
@@ -439,6 +439,7 @@ class Camera(RequestMachinery):
 
         if isinstance(config, dict):
             _log.warning("Using old-style camera config, please update")
+            config = config.copy()
             return CameraConfig(camera=self, **config)
 
         raise RuntimeError(f"Don't know how to make a config from {config} ({type(config)})")

--- a/scicamera/camera.py
+++ b/scicamera/camera.py
@@ -54,7 +54,8 @@ class CameraManager:
 
     def close_all(self) -> int:
         n_closed = 0
-        for idx in self.cameras.keys():
+        ids_to_close = list(self.cameras.keys())
+        for idx in ids_to_close:
             # FIXME(meawoppl) - this calls back into self.cleanup()
             self.cameras[idx].close()
             n_closed += 1

--- a/scicamera/camera.py
+++ b/scicamera/camera.py
@@ -513,7 +513,7 @@ class Camera(RequestMachinery):
         self.started = True
         _log.info("Camera started")
 
-    def start(self, config=None) -> None:
+    def start(self) -> None:
         """
         Start the camera system running.
 
@@ -524,10 +524,9 @@ class Camera(RequestMachinery):
         config - if not None this is used to configure the camera. This is just a
             convenience so that you don't have to call configure explicitly.
         """
-        if self.camera_config is None and config is None:
-            config = "preview"
-        if config is not None:
-            self.configure(config)
+        if self.camera_config is None:
+            _log.warning("Camera has not been configured, using preview config")
+            self.configure(self.preview_configuration)
         if self.camera_config is None:
             raise RuntimeError("Camera has not been configured")
         # By default we will create an event loop is there isn't one running already.

--- a/scicamera/camera.py
+++ b/scicamera/camera.py
@@ -23,7 +23,6 @@ from scicamera.request import CompletedRequest, LoopTask
 from scicamera.sensor_format import SensorFormat
 from scicamera.tuning import TuningContext
 
-
 _log = logging.getLogger(__name__)
 
 
@@ -265,7 +264,9 @@ class Camera(RequestMachinery):
         # The next two lines could be placed elsewhere?
         self.sensor_resolution = self.camera_properties_["PixelArraySize"]
         self.sensor_format = str(
-            self.camera.generate_configuration([libcamera.StreamRole.Raw]).at(0).pixel_format
+            self.camera.generate_configuration([libcamera.StreamRole.Raw])
+            .at(0)
+            .pixel_format
         )
 
         _log.info("Initialization successful.")
@@ -431,8 +432,6 @@ class Camera(RequestMachinery):
             requests.append(request)
         return requests
 
-
-
     def _config_opts(self, config: dict | CameraConfig) -> CameraConfig:
         if isinstance(config, CameraConfig):
             return config
@@ -442,7 +441,9 @@ class Camera(RequestMachinery):
             config = config.copy()
             return CameraConfig(camera=self, **config)
 
-        raise RuntimeError(f"Don't know how to make a config from {config} ({type(config)})")
+        raise RuntimeError(
+            f"Don't know how to make a config from {config} ({type(config)})"
+        )
 
     def configure(self, config: dict | CameraConfig) -> None:
         """Configure the camera system with the given configuration.
@@ -467,7 +468,9 @@ class Camera(RequestMachinery):
         self.camera_properties_ = lc_unpack(self.camera.properties)
 
         # Allocate all the frame buffers.
-        self.streams = [stream_config.stream for stream_config in camera_config.libcamera_config]
+        self.streams = [
+            stream_config.stream for stream_config in camera_config.libcamera_config
+        ]
 
         # TODO(meawoppl) - can be taken off public and used in the 1 function
         # that calls it.

--- a/scicamera/configuration.py
+++ b/scicamera/configuration.py
@@ -464,10 +464,6 @@ class CameraConfig:
 
         self.libcamera_config = libcamera_config
 
-        _log.debug(f"Streams: {self.stream_map}")
-
-        return stream_map
-
     def get_stream_map(self) -> Dict[str, Any]:
         # Record which libcamera stream goes with which of our names.
         stream_map = {}

--- a/scicamera/configuration.py
+++ b/scicamera/configuration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, replace
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import libcamera
 
@@ -391,7 +391,7 @@ class CameraConfig:
         )
 
     def _update_libcamera_stream_config(
-        libcamera_stream_config, stream_config: StreamConfig, buffer_count: int
+        self, libcamera_stream_config, stream_config: StreamConfig, buffer_count: int
     ) -> None:
         # Update the libcamera stream config with ours.
         libcamera_stream_config.size = libcamera.Size(*stream_config.size)
@@ -418,9 +418,7 @@ class CameraConfig:
         libcamera_config = lc_camera.generate_configuration(roles)
         libcamera_config.transform = self.transform
         self._update_libcamera_stream_config(
-            libcamera_config.at(main_index),
-            self.main,
-            self.buffer_count
+            libcamera_config.at(main_index), self.main, self.buffer_count
         )
         libcamera_config.at(main_index).color_space = self.color_space
         if self.lores is not None:
@@ -456,7 +454,7 @@ class CameraConfig:
         if raw_index >= 0:
             self.raw = StreamConfig.from_lc_stream_config(
                 libcamera_config.at(raw_index)
-            )      
+            )
 
         # Configure the lc_camera instance
         code = lc_camera.configure(libcamera_config)
@@ -465,7 +463,6 @@ class CameraConfig:
         _log.debug(f"Final configuration: {self}")
 
         self.libcamera_config = libcamera_config
-
 
         _log.debug(f"Streams: {self.stream_map}")
 

--- a/scicamera/configuration.py
+++ b/scicamera/configuration.py
@@ -124,7 +124,8 @@ class CameraConfig:
     lores: Optional[StreamConfig | dict] = None
     raw: Optional[StreamConfig | dict] = None
 
-    libcamera_config: Optional[Any]
+    # This is set only after validation by libcamera
+    libcamera_config: Optional[Any] = None
 
     # TODO: Remove forward references.
     @property

--- a/tests/old/capture_dng_and_jpeg.py
+++ b/tests/old/capture_dng_and_jpeg.py
@@ -10,7 +10,7 @@ camera = Camera()
 camera.start_preview()
 
 preview_config = CameraConfig.for_preview(camera)
-camera.configure("preview")
+camera.configure(camera.preview_configuration)
 
 camera.start()
 camera.discard_frames(2)

--- a/tests/old/configurations.py
+++ b/tests/old/configurations.py
@@ -25,14 +25,14 @@ camera.still_configuration.enable_raw()
 half_res = tuple([v // 2 for v in camera.sensor_resolution])
 camera.still_configuration.raw.size = half_res
 
-camera.configure("preview")
+camera.configure(camera.preview_configuration)
 if camera.controls.ExposureTime != 10000:
     raise RuntimeError("exposure value was not set")
 config = camera.camera_configuration()
 if config.main.size != (800, 600):
     raise RuntimeError("preview resolution incorrect")
 
-camera.configure("video")
+camera.configure(camera.video_configuration)
 if camera.controls.FrameRate < 24.99 or camera.controls.FrameRate > 25.01:
     raise RuntimeError("framerate was not set")
 config = camera.camera_configuration()
@@ -41,7 +41,7 @@ if config.size != (800, 480):
 if config.format != "YUV420":
     raise RuntimeError("video format incorrect")
 
-camera.configure("still")
+camera.configure(camera.still_configuration)
 config = camera.camera_configuration()
 if config.raw.size != half_res:
     raise RuntimeError("still raw size incorrect")

--- a/tests/old/mode_test.py
+++ b/tests/old/mode_test.py
@@ -26,7 +26,7 @@ def check(raw_config, fps):
         camera,
         raw=raw_config,
     )
-    camera.configure("video")
+    camera.configure(camera.video_configuration)
 
     # Check we got the correct raw format
     assert camera.camera_configuration().raw.size == raw_config["size"]

--- a/tests/old/pick_mode.py
+++ b/tests/old/pick_mode.py
@@ -27,7 +27,7 @@ chosen_mode = available_modes[0]
 camera.video_configuration = CameraConfig.for_video(
     camera, raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
 )
-camera.configure("video")
+camera.configure(camera.video_configuration)
 
 # Set the fps
 fps = chosen_mode["fps"]

--- a/tests/old/still_capture_with_config.py
+++ b/tests/old/still_capture_with_config.py
@@ -15,6 +15,6 @@ camera.still_configuration.raw.size = camera.sensor_resolution
 camera.configure(camera.preview_configuration)
 camera.start()
 mature_after_frames_or_timeout(camera, 3)
-assert camera.capture_image(config="still").result()
+assert camera.capture_image(config=camera.still_configuration).result()
 camera.stop()
 camera.close()

--- a/tests/old/still_capture_with_config.py
+++ b/tests/old/still_capture_with_config.py
@@ -12,7 +12,8 @@ camera.still_configuration.size = (1600, 1200)
 camera.still_configuration.enable_raw()
 camera.still_configuration.raw.size = camera.sensor_resolution
 
-camera.start("preview")
+camera.configure(camera.preview_configuration)
+camera.start()
 mature_after_frames_or_timeout(camera, 3)
 assert camera.capture_image(config="still").result()
 camera.stop()


### PR DESCRIPTION
Simplify and cleanup what makes for an acceptable submission to camera-config.