### PR TITLE
Remove baked in configs

### DIFF
--- a/tests/old/capture_dng_and_jpeg.py
+++ b/tests/old/capture_dng_and_jpeg.py
@@ -10,7 +10,7 @@ camera = Camera()
 camera.start_preview()
 
 preview_config = CameraConfig.for_preview(camera)
-camera.configure(camera.preview_configuration)
+camera.configure(preview_config)
 
 camera.start()
 camera.discard_frames(2)

--- a/tests/old/mode_test.py
+++ b/tests/old/mode_test.py
@@ -22,11 +22,11 @@ def check(raw_config, fps):
     if raw_config["size"][0] * raw_config["size"][1] > 5e6:
         print("Not checking", raw_config)
         return
-    camera.video_configuration = CameraConfig.for_video(
+    video_config = CameraConfig.for_video(
         camera,
         raw=raw_config,
     )
-    camera.configure(camera.video_configuration)
+    camera.configure(video_config)
 
     # Check we got the correct raw format
     assert camera.camera_configuration().raw.size == raw_config["size"]

--- a/tests/old/pick_mode.py
+++ b/tests/old/pick_mode.py
@@ -24,10 +24,12 @@ if not available_modes:
 
 chosen_mode = available_modes[0]
 
-camera.video_configuration = CameraConfig.for_video(
+video_config = CameraConfig.for_video(camera)
+
+video_configuration = CameraConfig.for_video(
     camera, raw={"size": chosen_mode["size"], "format": chosen_mode["format"].format}
 )
-camera.configure(camera.video_configuration)
+camera.configure(video_configuration)
 
 # Set the fps
 fps = chosen_mode["fps"]

--- a/tests/old/still_capture_with_config.py
+++ b/tests/old/still_capture_with_config.py
@@ -1,20 +1,23 @@
 #!/usr/bin/python3
 # Use the configuration structure method to do a full res capture.
-from scicamera import Camera
+from scicamera import Camera, CameraConfig
 from scicamera.testing import mature_after_frames_or_timeout
 
 camera = Camera()
 
 # We don't really need to change anything, but let's mess around just as a test.
-camera.preview_configuration.size = (800, 600)
-camera.preview_configuration.format = "YUV420"
-camera.still_configuration.size = (1600, 1200)
-camera.still_configuration.enable_raw()
-camera.still_configuration.raw.size = camera.sensor_resolution
+preview_config = CameraConfig.for_preview(camera)
+preview_config.size = (800, 600)
+preview_config.format = "YUV420"
 
-camera.configure(camera.preview_configuration)
+still_config = CameraConfig.for_still(camera)
+still_config.size = (1600, 1200)
+still_config.enable_raw()
+still_config.raw.size = camera.sensor_resolution
+
+camera.configure(preview_config)
 camera.start()
 mature_after_frames_or_timeout(camera, 3)
-assert camera.capture_image(config=camera.still_configuration).result()
+assert camera.capture_image(config=still_config).result()
 camera.stop()
 camera.close()

--- a/tests/old/video_with_config.py
+++ b/tests/old/video_with_config.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python3
 
 # Use the configuration structure method to do a full res capture.
-from scicamera import Camera
+from scicamera import Camera, CameraConfig
 
 camera = Camera()
 
 # We don't really need to change anything, but let's mess around just as a test.
-camera.video_configuration.size = (800, 480)
-camera.video_configuration.format = "YUV420"
+video_configuration = CameraConfig.for_video(camera)
+video_configuration.size = (800, 480)
+video_configuration.format = "YUV420"
 
 camera.start()
 camera.discard_frames(2).result()


### PR DESCRIPTION
Some premade configs follow around the camera object with complicated getters/setters. You can DIY that. It takes 10 seconds. If not, the default "preview" configuration will be used.