### PR TITLE
Tidy Up Vestigial Methods

### DIFF
--- a/scicamera/configuration.py
+++ b/scicamera/configuration.py
@@ -127,6 +127,13 @@ class CameraConfig:
     # This is set only after validation by libcamera
     libcamera_config: Optional[Any] = None
 
+    def get_stream_config(self, name: str) -> StreamConfig | None:
+        return {
+            "main": self.main,
+            "lores": self.lores,
+            "raw": self.raw,
+        }[name]
+
     # TODO: Remove forward references.
     @property
     def size(self):
@@ -161,16 +168,6 @@ class CameraConfig:
         if self.lores is not None:
             self.lores.align(optimal)
         # No sense trying to align the raw stream.
-
-    def get_config(self, config_name: str) -> StreamConfig:
-        # TODO(meawoppl) - backcompat shim. remove me.
-        if config_name == "main":
-            return self.main
-        if config_name == "lores":
-            return self.lores
-        if config_name == "raw":
-            return self.raw
-        raise ValueError("Unknown config name " + config_name)
 
     def get_stream_indices(self) -> Tuple[int, int, int]:
         """Get the main, lores, and raw stream indices.

--- a/scicamera/fake.py
+++ b/scicamera/fake.py
@@ -53,13 +53,13 @@ class FakeCompletedRequest(CompletedRequest):
     def release(self):
         pass
 
-    def get_config(self, name: str) -> Dict[str, Any]:
+    def get_camera_config(self) -> CameraConfig:
         """Fetch the configuration for the named stream."""
         return self.config
 
     def get_buffer(self, name: str) -> np.ndarray:
         """Make a 1d numpy array from the named stream's buffer."""
-        size = self.config.get_config(name).size
+        size = self.config.get_stream_config(name).size
         return make_fake_image(size).flatten()
 
     def get_metadata(self) -> Dict[str, Any]:

--- a/scicamera/request.py
+++ b/scicamera/request.py
@@ -50,7 +50,7 @@ class MappedBuffer:
 
 class AbstractCompletedRequest(ABC):
     @abstractmethod
-    def get_camera_config(self, name: str) -> CameraConfig:
+    def get_camera_config(self) -> CameraConfig:
         raise NotImplementedError()
 
     @abstractmethod
@@ -63,7 +63,7 @@ class AbstractCompletedRequest(ABC):
 
     def make_array(self, name: str) -> np.ndarray:
         """Make a 2d numpy array from the named stream's buffer."""
-        config = self.get_camera_config(name)
+        config = self.get_camera_config()
         stream_cfg = config.get_stream_config(name)
         w, h = stream_cfg.size
         stride = stream_cfg.stride

--- a/scicamera/request.py
+++ b/scicamera/request.py
@@ -50,7 +50,7 @@ class MappedBuffer:
 
 class AbstractCompletedRequest(ABC):
     @abstractmethod
-    def get_config(self, name: str) -> CameraConfig:
+    def get_camera_config(self, name: str) -> CameraConfig:
         raise NotImplementedError()
 
     @abstractmethod
@@ -63,8 +63,8 @@ class AbstractCompletedRequest(ABC):
 
     def make_array(self, name: str) -> np.ndarray:
         """Make a 2d numpy array from the named stream's buffer."""
-        config = self.get_config(name)
-        stream_cfg = config.get_config(name)
+        config = self.get_camera_config(name)
+        stream_cfg = config.get_stream_config(name)
         w, h = stream_cfg.size
         stride = stream_cfg.stride
 
@@ -104,7 +104,7 @@ class AbstractCompletedRequest(ABC):
 
     def make_image(self, name: str) -> Image.Image:
         """Make a PIL image from the named stream's buffer."""
-        fmt = self.get_config(name).format
+        fmt = self.get_camera_config().format
         if fmt == "MJPEG":
             buffer = self.get_buffer(name)
             return Image.open(io.BytesIO(buffer))
@@ -166,7 +166,7 @@ class CompletedRequest(AbstractCompletedRequest):
             self.cleanup()
             self.request = None
 
-    def get_config(self, name: str) -> CameraConfig:
+    def get_camera_config(self) -> CameraConfig:
         """Fetch the configuration for the named stream."""
         return self.config
 


### PR DESCRIPTION
This snags a couple bits of config machinery that were genrally misnamed in one way or another. No top level name changes, but some internal handles are less confusing and properly typed now.